### PR TITLE
Include yepnope to load polyfills

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "rainbow": "~1.1.9"
+    "rainbow": "~1.1.9",
+    "yepnope": "~1.5.4"
   }
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,1 +1,58 @@
-//Client-side JS goes here.
+var IntlDocs = (function () {
+    var queue = [],
+        statuses = [];
+
+    function checkFlush() {
+        var i = 0, length = statuses.length, ready = true;
+        while (i < length && ready) {
+            if (!statuses[i].ready) {
+                ready = false;
+            }
+            i++;
+        }
+        if (ready) {
+            for (i = 0, length = queue.length; i < length; i++) {
+                queue[i]();
+            }
+            queue = [];
+        }
+    }
+
+    function load(fn) {
+        var status = {
+            ready: false
+        };
+        function callback() {
+            status.ready = true;
+            checkFlush();
+        }
+        statuses.push(status);
+        fn(callback);
+    }
+
+    return {
+        polyfill: function (config) {
+            load(function (callback) {
+                yepnope({
+                    test: config.test,
+                    nope: config.url,
+                    complete: callback
+                });
+            });
+        },
+        script: function (source) {
+            load(function (callback) {
+                yepnope.injectJs(source, callback);
+            });
+        },
+        ready: function (callback) {
+            queue.push(callback);
+            checkFlush();
+        }
+    };
+}());
+
+IntlDocs.polyfill({
+    test: !!window.Intl,
+    url: 'http://yui.yahooapis.com/platform/intl/0.1.2/Intl.js'
+});

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -17,6 +17,7 @@
     </div>
     <script src="/bower_components/rainbow/js/rainbow.min.js"></script>
     <script src="/bower_components/rainbow/js/language/generic.js"></script>
+    <script src="/bower_components/yepnope/yepnope.js"></script>
     <script src="/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The plan would be to write examples in Handlebars partials, include them in code blocks and include them inside script tags like this:

``` html
<script>
IntlDocs.ready(function () {
 {{>partial}}
});
</script>
```
