### PR TITLE
Use `intl-messageformat` from Bower

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,6 @@ app.use(compress());
 app.use(middleware.intl);
 app.use(router);
 app.use('/bower_components/',  express.static(config.dirs.bower));
-app.use('/intl/', express.static(config.dirs.intl));
 app.use(express.static(config.dirs.pub));
 
 // When we get a favicon, we can uncomment this line

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "rainbow": "~1.1.9",
-    "yepnope": "~1.5.4"
+    "yepnope": "~1.5.4",
+    "intl-messageformat": "~0.1.0"
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -10,7 +10,6 @@ exports = module.exports = {
         i18n    : path.resolve('i18n/'),
         pub     : path.resolve('public/'),
         bower   : path.resolve('bower_components/'),
-        intl    : path.resolve('node_modules/intl-messageformat/build/'),
         views   : path.resolve('views/pages/'),
         layouts : path.resolve('views/layouts/'),
         partials: path.resolve('views/partials/')

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -4,7 +4,7 @@
         // TODO: expose these URLs through Express State instead
         baseUrl   = 'http://yui.yahooapis.com/combo?platform/intl/0.1.2/Intl.min.js&platform/intl/0.1.2/locale-data/jsonp/',
         comboUrl  = baseUrl + locale + '.js',
-        intlMessageFormatUrl = '/intl/intl-messageformat.complete.min.js';
+        intlMessageFormatUrl = '/bower_components/intl-messageformat/build/intl-messageformat.complete.min.js';
 
     yepnope([{
         test : !!window.Intl,


### PR DESCRIPTION
Replacing `intl-messageformat` with Bower version after publishing.
