### PR TITLE
Expose all translations for client-side switching

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,13 @@ app.engine(hbs.extname, hbs.engine);
 app.set('view engine', hbs.extname);
 app.set('views', config.dirs.views);
 
+var allTranslations = config.locales.reduce(function (translations, locale) {
+    translations[locale] = require(path.join(config.dirs.i18n, locale));
+    return translations;
+}, {});
+
+app.expose(allTranslations, 'translations', { cache: true });
+
 // -- Middleware ---------------------------------------------------------------
 
 var router = express.Router();

--- a/middleware/intl.js
+++ b/middleware/intl.js
@@ -8,11 +8,7 @@ module.exports = function (req, res, next) {
     var app      = req.app,
         locales  = app.get('locales'),
         locale   = req.acceptsLanguage(locales) || app.get('default locale'),
-        messages = require(path.join(config.dirs.i18n, locale)),
-        allMessages = locales.reduce(function (translations, locale) {
-            translations[locale] = require(path.join(config.dirs.i18n, locale));
-            return translations;
-        }, {});
+        messages = require(path.join(config.dirs.i18n, locale));
 
     req.locale = locale;
 
@@ -22,7 +18,6 @@ module.exports = function (req, res, next) {
 
     // TODO: Handle/merge and Expose the common formats.
     res.expose(res.locals.intl, 'intl')
-    res.expose(allMessages, 'translations');
 
     next();
 };


### PR DESCRIPTION
@awooldri needed all of the translations to already be exposed all on the page to switch between languages on the client.

This exposes all of the translations under `APP.translations` so the example can easily be re-rendered.
