### PR TITLE
Initial commit of IntlMessageFormat Docs

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ router.route('/quickstart/node/')
     .get(routes.render('quickstart/node'));
 
 router.route('/handlebars/').get(routes.handlebars);
-
 router.route('/dust/').get(routes.dust);
 router.route('/react/').get(routes.react);
 router.route('/overview/').get(routes.render('overview'));
+router.route('/javascript/').get(routes.render('javascript'));

--- a/views/pages/javascript.hbs
+++ b/views/pages/javascript.hbs
@@ -1,0 +1,368 @@
+{{setTitle "Intl Message Format"}}
+
+<h1>The Intl Message Format API</h1>
+
+{{sectionHeading "Overview"}}
+
+<p>
+    The IntlMessageFormat API aims to provide a standardized way to concatenate strings with localization support in JavaScript on both the server and client. It allows you to format a string with placeholders, including plural and select support to create localized messages.
+</p>
+
+{{sectionHeading "Basis"}}
+<p>
+    This implementation is based on the <a href="http://wiki.ecmascript.org/doku.php?id=globalization:messageformatting">Strawman Draft</a>. There are a few places this implementation diverges from the strawman draft. One such place is the pattern after it has been parsed. The strawman draft indicates the parsed arguments should be "flat" - where grouping options are at the same level as the {{code "type"}} and {{code "valueName"}}. This, as an example, would look like:
+</p>
+
+{{#code "js"}}
+{
+    type: "plural",
+    valueName: "TRAVELER_COUNT",
+    zero: "No travelers",
+    one: "One traveler",
+    two: "Two travelers",
+    few: "There are a few travelers",
+    many: "There are many travelers",
+    other: "There are a lot of travelers"
+}
+{{/code}}
+<p>
+    This implementation takes a readability approach and places grouping options in an {{code "options"}} key. This looks like:
+</p>
+
+{{#code "js"}}
+{
+    type: "plural",
+    valueName: "TRAVELER_COUNT",
+    options: {
+        zero: "No travelers",
+        one: "One traveler",
+        two: "Two travelers",
+        few: "There are a few travelers",
+        many: "There are many travelers",
+        other: "There are a lot of travelers"
+    }
+}
+{{/code}}
+
+{{sectionHeading "How It Works"}}
+
+<p>Messages are provided into the constructor as an {{code "Array"}} or {{code "String"}} messages.</p>
+
+{{#code "js"}}
+var msg = new IntlMessageFormat(pattern, locale, [optFieldFormatters]);
+{{/code}}
+
+<p>If a {{code "String"}} is provided, it is parsed into a workable {{code "Array"}} of tokens. This means:</p>
+
+{{#code "js"}}
+"Welcome to {CITY}, {STATE}!"
+{{/code}}
+
+<p>becomes:</p>
+
+{{#code "js"}}
+[
+    "Welcome to ",
+    {
+        valueName: "CITY"
+    },
+    ", "
+    {
+        valueName: "STATE"
+    },
+    "!"
+]
+{{/code}}
+
+<p>
+    The pattern {{code "Array"}} may contain {{code "Strings"}} or {{code "Objects"}}. Read more about [Token Objects](#token-objects).
+</p>
+
+<p>
+    The pattern is stored internally until the {{code "format()"}} method is called with an {{code "Object"}} containing parameters for generating the message. The pattern is then processed by converting the tokens into strings based on the parameters provided and concatenating the values together.
+</p>
+
+
+{{sectionHeading "Features"}}
+
+<p>
+    Custom formatters can be used to format the value <em>after</em> it is gathered from the original process. Custom formatters are stored in the message during construction as the third parameter. Formatters are denoted in the argument with a comma (,) followed by the formatter name.
+</p>
+
+<p>For example you can ensure that certain tokens are always upper cased:</p>
+
+{{#code "js"}}
+var msg = new IntlMessageFormat("Then they yelled '{YELL, upper}!'", "en", {
+    "upper": function (val, locale) {
+        return val.toString().toUpperCase();
+    }
+});
+
+var m = msg.format({ YELL: "suprise" });
+
+// Then they yelled 'SUPRISE!'
+{{/code}}
+
+
+{{sectionHeading "Installation"}}
+
+You can install {{code "intl-messageformat"}} via npm:
+
+{{#code "shell"}}
+npm install intl-messageformat
+{{/code}}
+
+
+{{sectionHeading "Usage"}}
+
+<h3>IntlMessageFormat Constructor</h3>
+
+<p>
+    To create a message to format, use the IntlMessageFormat constructor. The constructor has three parameters:
+</p>
+
+<dl class="parameters-list">
+    <dt>{{code "pattern: String|Array"}}</dt>
+    <dd>Array or string that serves as formatting pattern. Use array for plural and select messages, otherwise use string form.</dd>
+
+    <dt>{{code "locale: String"}}</dt>
+    <dd>Locale for string formatting. The locale is optional, but it is highly encouraged to provide a locale. If you do not provide a locale, the default locale will be used.</dd>
+
+    <dt>{{code "optFieldFormatters: Object"}}</dt>
+    <dd>(optional) Holds user defined formatters for each field</dd>
+</dl>
+
+<h3>Creating a Message in Node.js</h3>
+
+{{#code "js"}}
+var IntlMessageFormat = require('intl-messageformat');
+
+// load some locales that you care about
+require('intl-messageformat/locale-data/en');
+require('intl-messageformat/locale-data/ar');
+require('intl-messageformat/locale-data/pl');
+
+var msg = new IntlMessageFormat("My name is {NAME}.", "en-US");
+{{/code}}
+
+<h3>Creating a Message in a Browser</h3>
+{{#code "js"}}
+var msg = new IntlMessageFormat("My name is {NAME}.", "en-US");
+{{/code}}
+
+<h3>Formatting a Message</h3>
+
+<p>
+    Once the message is created, formatting the message is done by calling the {{code "format()"}} method of the instantiated object:
+</p>
+
+{{#code "js"}}
+var myNameIs = msg.format({ NAME: "Ferris Wheeler"});
+
+// "My name is Ferris Wheeler."
+{{/code}}
+
+
+
+
+{{sectionHeading "API"}}
+
+<h3>Constructor</h3>
+
+<p>
+    Creates an IntlMessageFormat object from a pattern, locale and field formatters. String patterns are broken down to Arrays. Objects should match the following pattern:
+</p>
+
+{{#code "js"}}
+{
+    type: 'plural|select',
+    valueName: 'string',
+    offset: 1, // consistent offsets for plurals
+    options: {}, // keys match options for plurals and selects
+    format: 'string|function' // strings are matched to internal formatters
+}
+{{/code}}
+
+<h3>Parameters</h3>
+
+<dl class="parameters-list">
+
+    <dt>{{code "pattern: Array|String"}}</dt>
+    <dd>
+        {{code "Array"}} or {{code "String"}} that serves as formatting pattern. An {{code "Array"}} may consist of {{code "Strings"}} and [Token Objects](#token-objects).
+    </dd>
+
+    <dt>{{code "locale: String"}}</dt>
+    <dd>
+        Locale for string formatting and when using plurals and formatters.
+    </dd>
+
+    <dt>{{code "optFieldFormatters: Object"}}</dt>
+    <dd>Holds user defined formatters for each field</dd>
+
+</dl>
+
+<h3>Instance Methods</h3>
+
+<h4>{{code "format(data)"}}</h4>
+<p>
+    Formats the pattern with supplied parameters. Dates, times and numbers are formatted in locale sensitive way when used with a formatter.
+</p>
+
+<strong>Parameters</strong>
+
+<dl class="parameters-list">
+    <dt>{{code "data: Object"}}</dt>
+    <dd>Object used to choose options when formatting the message</dd>
+    <dt>{{code "resolvedOptions"}}</dt>
+    <dd><em>NOT YET DETERMINED:</em> Returns resolved options, in this case supported locale.</dd>
+</dl>
+
+
+<h3>Token Objects</h3>
+<p>
+
+    Token objects are created when the string is parsed. If you wish, you can create your own token objects. Token objects should always at least contain a {{code "valueName"}}. There are a few other items that can be included:
+</p>
+
+<dl class="parameters-list">
+    <dt>{{code "type: String"}}</dt>
+    <dd>{{code "plural"}} or {{code "select"}} to identify the grouping type. Other values such as {{code "number"}} and {{code "date"}} are used to identify the type of the value and can be combined with a {{code "format"}} string to identify a formatter to be used.</dd>
+
+    <dt>{{code "valueName: String"}}</dt>
+    <dd>key to match the {{code "format"}} object</dd>
+
+    <dt>{{code "format: String|Function"}}</dt>
+    <dd>formatter used on the value after is discovered. Specifying the {{code "type"}} is {{code "'number'"}} and the {{code "format"}} is {{code "'integer'"}} would result in the default formatter {{code "number_integer"}} being called</dd>
+
+    <dt>{{code "options: Object"}}</dt>
+    <dd>each key should be matched based on the {{code "type"}} specified</dd>
+
+    <dt>{{code "zero: String|Array"}}</dt>
+    <dd>(plural) Matched when the locale determines that the number is in the {{code "'zero'"}} pluralization class</dd>
+
+    <dt>{{code "one: String|Array"}}</dt>
+    <dd>(plural) Matched when the locale determines that the number is in the {{code "'one'"}} pluralization class</dd>
+
+    <dt>{{code "two: String|Array"}}</dt>
+    <dd>(plural) Matched when the locale determines that the number is in the {{code "'two'"}} pluralization class</dd>
+
+    <dt>{{code "few: String|Array"}}</dt>
+    <dd>(plural) Matched when the locale determines that the number is in the {{code "'few'"}} pluralization class</dd>
+
+    <dt>{{code "many: String|Array"}}</dt>
+    <dd>(plural) Matched when the locale determines that the number is in the {{code "'many'"}} pluralization class</dd>
+
+    <dt>{{code "male: String|Array"}}</dt>
+    <dd>(plural) Matched when the {{code "valueName"}} returns {{code "'male'"}}</dd>
+
+    <dt>{{code "female: String|Array"}}</dt>
+    <dd>(plural) Matched when the {{code "valueName"}} returns {{code "'female'"}}</dd>
+
+    <dt>{{code "neuter: String|Array"}}</dt>
+    <dd>(plural) Matched when the {{code "valueName"}} returns {{code "'neuter'"}}</dd>
+
+    <dt>{{code "other: String|Array"}}</dt>
+    <dd>(plural or select) Matched when {{code "_normalizeCount"}} returns {{code "'other'"}}, the {{code "valueName"}} returns {{code "'other'"}} or the returned value from either of those returns a value that is not specified. For instance, if {{code "'male'"}} is returned and {{code "'male'"}} is not specified, other will be matched.</dd>
+
+</dl>
+
+<p>
+    When {{code "options"}} is matched and returns an {{code "Array"}}, that {{code "Array"}} is then processed in the same manner. This means, large complex, conditional messages can be formed by defining the pattern as such.
+</p>
+
+
+{{sectionHeading "Locale Data"}}
+
+<p>
+    This package ships with locale data for the top-level locales (e.g. {{code "en"}} but not {{code "en-US"}}). You can load the library and locale(s) using any of the following subpaths in the package:
+</p>
+
+<ul>
+    <li>Load the base and then just the locale(s) that you need: {{code "intl-messageformat/index.js"}} and {{code "intl-messageformat/locale-data/{locale}.js"}}</li>
+
+    <li>Load the base with a single locale builtin: {{code "intl-messageformat/build/intl-messageformat.{locale}.js')"}}. You can then optionally add more locale(s) as above.</li>
+
+    <li>Load all locales: {{code "intl-messageformat/build/intl-messageformat.complete.js"}}</li>
+</ul>
+
+
+<h3>Loading Locale Data in Node.js</h3>
+
+<p>
+    <strong>Please note</strong> that if you are loading from the {{code "locale-data/"}} directory that those files are expecting the library to be available in the {{code "IntlMessageFormat"}} variable.
+</p>
+
+<h3>Loading Locale Data in a Browser</h3>
+
+<p>
+    Every {{code "intl-messageformat/build/*.js"}} file also has an {{code "intl-messageformat/build/*.min.js"}} equivalent which has already been minified.
+</p>
+
+
+{{sectionHeading "Examples"}}
+
+<h3>Simple String</h3>
+{{#code "js"}}
+var msg = new IntlMessageFormat("My name is {name}.", "en-US");
+
+var myNameIs = msg.format({ name: "Ferris Wheeler"});
+
+// "My name is Ferris Wheeler."
+{{/code}}
+
+
+<h3>Complex Formatting</h3>
+{{#code "js"}}
+var msg = new IntlMessageFormat(['Some text before ', {
+    type: 'plural',
+    valueName: 'NUM_PEOPLE',
+    offset: 1,
+    options: {
+        one: 'Some message ${PH} with ${#} value',
+
+        few: ['Optional prefix text for |few| ', {
+            type: 'select',
+            valueName: 'GENDER',
+            options: {
+                male: 'Text for male option with \' single quotes',
+                female: 'Text for female option with {}',
+                other: 'Text for default'
+            }
+        }, ' optional postfix text'],
+
+        other: 'Some messages for the default'
+    }
+}, ' and text after'], "en-US");
+
+var complex = msg.format({
+    NUM_PEOPLE: 4,
+    PH: 'whatever',
+    GENDER: 'male'
+});
+
+// "Some text before Optional prefix text for |few| Text for male option with ' single quotes optional postfix text and text after"
+{{/code}}
+
+<h3>User Defined Formatters</h3>
+<p>
+    User defined formatters are provided to the IntlMessageFormat as the third parameter. To denote a key should be process through a formatter, you need only provide the formatter name after the token key. Such as, {{code "{key}"}} would then become {{code "{key, formatter}"}}. This is an example of using the Intl.NumberFormat to create a currency formatter.
+</p>
+
+{{#code "js"}}
+var msg = new IntlMessageFormatter("I just made {TOTAL, currency}!!", "en-US", {
+    currency: function (val, locale) {
+        return new Intl.NumberFormat(val, {
+            style: 'currency',
+            currency: 'USD',
+            currencyDisplay: 'symbol'
+        });
+    }
+});
+
+var payday = msg.format({ TOTAL: 3 });
+
+// I just made $3.00!!
+{{/code}}
+
+

--- a/views/pages/overview.hbs
+++ b/views/pages/overview.hbs
@@ -26,8 +26,10 @@
 </p>
 
 <ul>
+    <li><a href="/javascript/">Use the JavaScript API</a></li>
     <li><a href="/handlebars/">Use Intl with Handlebars</a></li>
-    <li>Use Intl with Dust (coming soon)</li>
+    <li><a href="/dust/">Use Intl with Dust</a></li>
+    <li><a href="/react/">Use Intl with React</a></li>
 </ul>
 
 <h3>Client-side Internationalization</h3>


### PR DESCRIPTION
I just converted the current IntlMessageFormat docs from Markdown to HBS, and changed the order of the headings to make more sense (API now comes before Examples). 
