### PR TITLE
Simplify getExamples

### DIFF
--- a/lib/examples.js
+++ b/lib/examples.js
@@ -31,14 +31,18 @@ there to help with exposing the templates client-side via express-state.
 
 
 var Promise        = require('ypromise'),
-    fs             = require('pfs'),
+    fs             = require('fs'),
     path           = require('path'),
     Dust           = require('dustjs-linkedin'),
     Hbs            = require('handlebars'),
     React          = require('react'),
     ReactIntlMixin = require('react-intl');
 
-var config = require('../config');
+var config = require('../config'),
+    utils  = require('./utils');
+
+var readFile = utils.promisify(fs.readFile),
+    readdir  = utils.promisify(fs.readdir);
 
 // ----------------------------------------------
 
@@ -57,7 +61,7 @@ function getExamples (type, opts) {
         var dir      = path.join(examplesDir, filePath),
             fileName = path.basename(dir);
 
-        return fs.readFile(dir, 'utf8').then(function (contents) {
+        return readFile(dir, 'utf8').then(function (contents) {
             return compile(type, {
                 identifier: fileName,
                 name      : path.basename(fileName, path.extname(fileName)),
@@ -71,7 +75,7 @@ function getExamples (type, opts) {
     if (!opts.cache || !examples[type]) {
         examplesDir = path.join(config.dirs.examples, type);
 
-        examples[type] = fs.readdir(examplesDir)
+        examples[type] = readdir(examplesDir)
             .then(function (allFiles) {
                 return Promise.all(
                     allFiles.filter(isTemplateFile).map(readAndCompile)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,13 @@
 var STATUS_CODES = require('http');
 
-var fs   = require('fs'),
-    path = require('path');
+var fs      = require('fs'),
+    path    = require('path'),
+    Promise = require('ypromise');
 
 exports.error      = error;
 exports.requireDir = requireDir;
 exports.extend     = extend;
+exports.promisify  = promisify;
 
 // -----------------------------------------------------------------------------
 
@@ -52,4 +54,20 @@ function extend(obj) {
     });
 
     return obj;
+}
+
+function promisify(fn) {
+    return function () {
+        var args = Array.prototype.slice.call(arguments);
+        return new Promise(function (resolve, reject) {
+            args.push(function (err, result) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(result);
+                }
+            });
+            fn.apply(null, args);
+        });
+    }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "dustjs-linkedin": "~2.4.0",
     "dust-helper-intl": "0.0.3",
     "ypromise": "~0.2.3",
-    "pfs": "^0.10.20",
     "react": "~0.10.0",
     "react-intl": "0.1.0-rc-1"
   },


### PR DESCRIPTION
@tilomitra I used the `pfs` module to replace `fs`, which simplified a couple of functions. Also, I removed the use of `new Promise` in `compile` since it's just a synchronous operation.
