### PR TITLE
Manage trailing slashes with express-slash

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,9 +18,9 @@ var config     = require('./config'),
     middleware = require('./middleware'),
     routes     = require('./routes');
 
-var app = module.exports = express();
-
 // -----------------------------------------------------------------------------
+
+var app = module.exports = express();
 
 hbsIntl.registerWith(hbs.handlebars);
 expstate.extend(app);
@@ -47,11 +47,19 @@ app.expose(allTranslations, 'translations', { cache: true });
 
 // -- Middleware ---------------------------------------------------------------
 
-var router = express.Router();
+var router = express.Router({
+    caseSensitive: app.get('case sensitive routing'),
+    strict       : app.get('strict routing')
+});
+
+if (app.get('env') === 'development') {
+    app.use(middleware.logger('tiny'));
+}
 
 app.use(compress());
 app.use(middleware.intl);
 app.use(router);
+app.use(middleware.slash());
 app.use('/bower_components/',  express.static(config.dirs.bower));
 app.use(express.static(config.dirs.pub));
 
@@ -60,19 +68,16 @@ app.use(express.static(config.dirs.pub));
 
 // -- Routes -------------------------------------------------------------------
 
-router.route('/').get(routes.render('home', 'home'));
+router.get('/', routes.render('home', 'home'));
 
-router.route('/quickstart')
-    .get(routes.render('quickstart'));
-router.route('/quickstart/browser')
-    .get(routes.render('quickstart/browser'));
-router.route('/quickstart/node')
-    .get(routes.render('quickstart/node'));
+router.get('/quickstart/',        routes.render('quickstart'));
+router.get('/quickstart/browser', routes.render('quickstart/browser'));
+router.get('/quickstart/node',    routes.render('quickstart/node'));
 
-router.route('/handlebars').get(routes.handlebars);
-router.route('/dust').get(routes.dust);
-router.route('/react').get(routes.react);
-router.route('/overview').get(routes.render('overview'));
-router.route('/faq').get(routes.render('faq'));
-router.route('/javascript').get(routes.render('javascript'));
-router.route('/github').get(routes.render('github'));
+router.get('/handlebars', routes.handlebars);
+router.get('/dust', routes.dust);
+router.get('/react', routes.react);
+router.get('/overview', routes.render('overview'));
+router.get('/faq', routes.render('faq'));
+router.get('/javascript', routes.render('javascript'));
+router.get('/github', routes.render('github'));

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -3,3 +3,6 @@
 var utils = require('../lib/utils');
 
 exports = module.exports = utils.requireDir(__dirname);
+
+exports.logger = require('morgan');
+exports.slash  = require('express-slash');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "express": "4.x",
     "express3-handlebars": "0.5.0",
-    "express-slash": "1.0.0",
+    "express-slash": "^2.0.0",
     "handlebars": "^2.0.0-alpha.4",
     "compression": "~1.0.3",
     "errorhandler": "~1.0.1",
@@ -29,7 +29,8 @@
     "dust-helper-intl": "0.0.3",
     "ypromise": "~0.2.3",
     "react": "~0.10.0",
-    "react-intl": "0.1.0-rc-1"
+    "react-intl": "0.1.0-rc-1",
+    "morgan": "^1.1.1"
   },
   "devDependencies": {
     "bower": "~1.3.4"


### PR DESCRIPTION
This adds express-slash middleware to have canonical URLs with trailing slashes (or not), and redirects to the canonical form.

I also added basic logging to the app in dev (used this to test that express-slash was working correctly).

**Note:** When clicking around the links on the site they are pointing to the non-canonical form of the URLs, causing a redirect to always happen. This is not ideal, and URLs should not be hard coded because this kind of thing happens.
