### PR TITLE
Conform page titles with h1

### DIFF
--- a/views/pages/dust.hbs
+++ b/views/pages/dust.hbs
@@ -1,4 +1,4 @@
-{{setTitle "IntlJS Dust Helpers"}}
+{{setTitle "Dust Helpers for Internationalization"}}
 <h1>Dust Helpers for Internationalization</h1>
 
 <p>

--- a/views/pages/github.hbs
+++ b/views/pages/github.hbs
@@ -1,4 +1,4 @@
-{{setTitle "GitHub Repositories"}}
+{{setTitle "Find us on GitHub"}}
 <h1>Find us on GitHub</h1>
 <p>
     The IntlJS modules that are referenced on this site are all open-source and available on GitHub through the BSD License. Instead of having one large repository, we have several smaller repositories; one for each module.

--- a/views/pages/handlebars.hbs
+++ b/views/pages/handlebars.hbs
@@ -1,4 +1,4 @@
-{{setTitle "IntlJS Handlebars Helpers"}}
+{{setTitle "Handlebars Helpers for Internationalization"}}
 
 <h1>Handlebars Helpers for Internationalization</h1>
 

--- a/views/pages/javascript.hbs
+++ b/views/pages/javascript.hbs
@@ -1,4 +1,4 @@
-{{setTitle "Intl Message Format API"}}
+{{setTitle "The Intl Message Format API"}}
 <h1>The Intl Message Format API</h1>
 
 {{sectionHeading "Overview"}}

--- a/views/pages/overview.hbs
+++ b/views/pages/overview.hbs
@@ -1,4 +1,4 @@
-{{setTitle "Internationalization Overview"}}
+{{setTitle "Client and Server JavaScript Internationalization"}}
 
 <h1>Client and Server JavaScript Internationalization</h1>
 

--- a/views/pages/quickstart/index.hbs
+++ b/views/pages/quickstart/index.hbs
@@ -1,4 +1,4 @@
-{{setTitle "Get Started"}}
+{{setTitle "Get Started with JavaScript Internationalization"}}
 <h1>Get Started with JavaScript Internationalization</h1>
 
 <p>

--- a/views/pages/react.hbs
+++ b/views/pages/react.hbs
@@ -1,4 +1,4 @@
-{{setTitle "IntlJS React Helpers"}}
+{{setTitle "React Helpers for Internationalization"}}
 
 <h1>React Helpers for Internationalization</h1>
 


### PR DESCRIPTION
I think all page titles should conform to `h1` texts to avoid confusion.
