### PR TITLE
Remove tailing slash for wholeness

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ app.use(express.static(config.dirs.pub));
 
 router.get('/', routes.render('home', 'home'));
 
-router.get('/quickstart/',        routes.render('quickstart'));
+router.get('/quickstart',         routes.render('quickstart'));
 router.get('/quickstart/browser', routes.render('quickstart/browser'));
 router.get('/quickstart/node',    routes.render('quickstart/node'));
 


### PR DESCRIPTION
There seems to be a tailing slash at the page only `/quickstart/`. I think this shouldn't even exist for wholeness.
