### PR TITLE
npm postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "xunit-file": "~0.0.5"
   },
   "scripts": {
-    "test": "_mocha tests/index.js"
+    "test": "_mocha tests/index.js",
+    "postinstall": "bower install && grunt"
   },
   "yahoo": {
     "bugzilla": {


### PR DESCRIPTION
I often forget to run `npm install`, `bower install` and `grunt` before run `npm start`, so I'd like to put `postinstall` script.

This is similar stuff with `pure-site`.
https://github.com/yui/pure-site/blob/aa9167fcdb73abcf857a2642e775cb1fbbfd85a3/package.json#L67
