### PR TITLE
Move to express-handlebars from express3-handlebars

### DIFF
--- a/lib/hbs.js
+++ b/lib/hbs.js
@@ -1,4 +1,4 @@
-var exphbs     = require('express3-handlebars'),
+var exphbs     = require('express-handlebars'),
     Handlebars = require('handlebars');
 
 var config  = require('../config'),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "express": "4.x",
-    "express3-handlebars": "0.5.0",
+    "express-handlebars": "^1.0.1",
     "express-slash": "^2.0.0",
     "handlebars": "^2.0.0-alpha.4",
     "compression": "~1.0.3",

--- a/views/pages/node.hbs
+++ b/views/pages/node.hbs
@@ -46,7 +46,7 @@ hbsIntl.registerWith(Handlebars);
 
 {{#code "js"}}
 var express = require('express'),
-exphbs  = require('express3-handlebars'),
+exphbs  = require('express-handlebars'),
 
 // Core Node modules to be used later
 var fs   = require('fs'),


### PR DESCRIPTION
The `express3-handlebars` has been renamed to `express-handlebars`.
- https://www.npmjs.org/package/express-handlebars
- https://www.npmjs.org/package/express3-handlebars
