### PR TITLE
Add "Message" tab to examples that use a message

### DIFF
--- a/examples/dust/message/meta.yaml
+++ b/examples/dust/message/meta.yaml
@@ -1,0 +1,1 @@
+messageId: photos

--- a/examples/handlebars/message/meta.yaml
+++ b/examples/handlebars/message/meta.yaml
@@ -1,0 +1,1 @@
+messageId: photos

--- a/examples/react/message/meta.yaml
+++ b/examples/react/message/meta.yaml
@@ -1,0 +1,1 @@
+messageId: photos

--- a/lib/examples.js
+++ b/lib/examples.js
@@ -1,21 +1,22 @@
 'use strict';
 
-var fs           = require('fs'),
-    path         = require('path'),
-    transformJSX = require('react-tools').transform;
+var fs           = require('fs');
+var path         = require('path');
+var transformJSX = require('react-tools').transform;
+var yaml         = require('js-yaml');
 
-var config          = require('../config'),
-    utils           = require('./utils'),
-    renderComponent = require('../lib/component').render;
+var config          = require('../config');
+var utils           = require('./utils');
+var renderComponent = require('../lib/component').render;
 
 exports.get    = getExamples;
 exports.render = renderExamples;
 
 // -----------------------------------------------------------------------------
 
-var readDir  = utils.promisify(fs.readdir),
-    readFile = utils.promisify(fs.readFile),
-    stat     = utils.promisify(fs.stat);
+var readDir  = utils.promisify(fs.readdir);
+var readFile = utils.promisify(fs.readFile);
+var stat     = utils.promisify(fs.stat);
 
 var cache = {};
 
@@ -73,13 +74,23 @@ function getSubdirs(dir, entries) {
 
 function processExamples(type, names) {
     return Promise.all(names.map(function (name) {
-        return getSourceFiles(type, name).then(function (sourceFiles) {
+        return Promise.all([
+            getMetadata(type, name),
+            getSourceFiles(type, name)
+        ]).then(function (files) {
+            var metadata    = files[0];
+            var sourceFiles = files[1];
+
             var example = {
                 id    : 'ex-' + type + '-' + name,
                 name  : name,
                 type  : type,
                 source: sourceFiles
             };
+
+            if (metadata && metadata.messageId) {
+                example.messageId = metadata.messageId;
+            }
 
             if (sourceFiles.context) {
                 example.context = evalContext(sourceFiles.context);
@@ -92,6 +103,18 @@ function processExamples(type, names) {
             return example;
         });
     }));
+}
+
+function getMetadata(type, name) {
+    var exampleDir = path.join(config.dirs.examples, type, name);
+
+    return readFile(path.join(exampleDir, 'meta.yaml'), 'utf8')
+        .then(function (contents) {
+            return yaml.safeLoad(contents);
+        }, function (err) {
+            // Surpress error, okay if an example doesn't have a meta.yaml file.
+            return null;
+        });
 }
 
 function getSourceFiles(type, name) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -158,7 +158,8 @@ p code {
     border-bottom: 1px solid var(--gainsboro);
 }
 .tabs-tab {
-    margin: 0 1rem -1px;
+    margin-top: 0;
+    margin-bottom: -1px;
     padding: 0.25rem 0rem;
     text-transform: uppercase;
     color: var(--black);
@@ -520,6 +521,12 @@ p code {
         padding-right: 0.625rem;
     }
 
+    .tabs-tab {
+        font-size: 0.875rem;
+        margin-left: 0.5rem;
+        margin-right: 0.5rem;
+    }
+
     .cta {
         font-size: 1.125rem;
         margin: 4rem 0 2rem;
@@ -624,6 +631,11 @@ p code {
 }
 
 @media screen and (min-width: 30em) {
+    .tabs-tab {
+        margin-left: 1rem;
+        margin-right: 1rem;
+    }
+
     .brand-mark {
         width: 9.2578rem;
         height: 2.5rem;
@@ -753,6 +765,9 @@ p code {
     .tabs-tablist {
         padding-left: 0;
         padding-right: 0;
+    }
+    .tabs-tab {
+        font-size: 1rem;
     }
 
     .code,

--- a/shared/components/dust-example.jsx
+++ b/shared/components/dust-example.jsx
@@ -33,27 +33,42 @@ export default React.createClass({
             currentLocale = this.state.currentLocale,
             messages      = this.props.intl.messages[currentLocale];
 
+        var tabs = [
+            <Tab label="Template" key="template">
+                <CodeBlock lang="html">
+                    {example.source.template}
+                </CodeBlock>
+            </Tab>,
+
+            <Tab label="Context" key="context">
+                <CodeBlock lang="javascript">
+                    {example.source.context}
+                </CodeBlock>
+            </Tab>,
+
+            <Tab label="Render" key="render">
+                <CodeBlock lang="javascript">
+                    {this.genderateRenderCode()}
+                </CodeBlock>
+            </Tab>
+        ];
+
+        // Insert a "Message" tab if the example uses an i18n message.
+        if (example.messageId) {
+            tabs.splice(1, 0,
+                <Tab label="Message" key="message">
+                    <CodeBlock>
+                        {messages[example.messageId]}
+                    </CodeBlock>
+                </Tab>
+            );
+        }
+
         return (
             <div id={example.id} className="example">
                 <div className="example-source">
                     <Tabs>
-                        <Tab label="Template">
-                            <CodeBlock lang="html">
-                                {example.source.template}
-                            </CodeBlock>
-                        </Tab>
-
-                        <Tab label="Context">
-                            <CodeBlock lang="javascript">
-                                {example.source.context}
-                            </CodeBlock>
-                        </Tab>
-
-                        <Tab label="Render">
-                            <CodeBlock lang="javascript">
-                                {this.genderateRenderCode()}
-                            </CodeBlock>
-                        </Tab>
+                        {tabs}
                     </Tabs>
                 </div>
 

--- a/shared/components/handlebars-example.jsx
+++ b/shared/components/handlebars-example.jsx
@@ -28,32 +28,47 @@ export default React.createClass({
     },
 
     render: function () {
-        var example       = this.props.example,
-            intl          = this.props.intl,
-            currentLocale = this.state.currentLocale,
-            messages      = intl.messages[currentLocale];
+        var example       = this.props.example;
+        var intl          = this.props.intl;
+        var currentLocale = this.state.currentLocale;
+        var messages      = intl.messages[currentLocale];
+
+        var tabs = [
+            <Tab label="Template" key="template">
+                <CodeBlock lang="html">
+                    {example.source.template}
+                </CodeBlock>
+            </Tab>,
+
+            <Tab label="Context" key="context">
+                <CodeBlock lang="javascript">
+                    {example.source.context}
+                </CodeBlock>
+            </Tab>,
+
+            <Tab label="Render" key="render">
+                <CodeBlock lang="javascript">
+                    {this.genderateRenderCode()}
+                </CodeBlock>
+            </Tab>
+        ];
+
+        // Insert a "Message" tab if the example uses an i18n message.
+        if (example.messageId) {
+            tabs.splice(1, 0,
+                <Tab label="Message" key="message">
+                    <CodeBlock>
+                        {messages[example.messageId]}
+                    </CodeBlock>
+                </Tab>
+            );
+        }
 
         return (
             <div id={example.id} className="example">
                 <div className="example-source">
                     <Tabs>
-                        <Tab label="Template">
-                            <CodeBlock lang="html">
-                                {example.source.template}
-                            </CodeBlock>
-                        </Tab>
-
-                        <Tab label="Context">
-                            <CodeBlock lang="javascript">
-                                {example.source.context}
-                            </CodeBlock>
-                        </Tab>
-
-                        <Tab label="Render">
-                            <CodeBlock lang="javascript">
-                                {this.genderateRenderCode()}
-                            </CodeBlock>
-                        </Tab>
+                        {tabs}
                     </Tabs>
                 </div>
 

--- a/shared/components/react-example.jsx
+++ b/shared/components/react-example.jsx
@@ -28,21 +28,36 @@ export default React.createClass({
 
         var ExampleComponent = example.getComponent();
 
+        var tabs = [
+            <Tab label="Component">
+                <CodeBlock lang="js">
+                    {example.source.component}
+                </CodeBlock>
+            </Tab>,
+
+            <Tab label="Render">
+                <CodeBlock lang="javascript">
+                    {this.genderateRenderCode()}
+                </CodeBlock>
+            </Tab>
+        ];
+
+        // Insert a "Message" tab if the example uses an i18n message.
+        if (example.messageId) {
+            tabs.splice(1, 0,
+                <Tab label="Message" key="message">
+                    <CodeBlock>
+                        {messages[example.messageId]}
+                    </CodeBlock>
+                </Tab>
+            );
+        }
+
         return (
             <div id={example.id} className="example">
                 <div className="example-source">
                     <Tabs>
-                        <Tab label="Component">
-                            <CodeBlock lang="js">
-                                {example.source.component}
-                            </CodeBlock>
-                        </Tab>
-
-                        <Tab label="Render">
-                            <CodeBlock lang="javascript">
-                                {this.genderateRenderCode()}
-                            </CodeBlock>
-                        </Tab>
+                        {tabs}
                     </Tabs>
                 </div>
 


### PR DESCRIPTION
These changes allow examples to contain a `meta.yaml` file, in which `messageId` can be defined, and when the example is rendered, a "Message" tab will automatically display the ICU Message string for the current locale.

![screenshot 2014-10-03 15 15 09](https://cloud.githubusercontent.com/assets/29096/4511168/9bd13b4a-4b31-11e4-8208-27047dc8a42d.png)
