### PR TITLE
This always evals example context before rendering

### DIFF
--- a/lib/examples.js
+++ b/lib/examples.js
@@ -85,17 +85,11 @@ function processExamples(type, names) {
                 id    : 'ex-' + type + '-' + name,
                 name  : name,
                 type  : type,
+                meta  : metadata,
                 source: sourceFiles
             };
 
-            if (metadata && metadata.messageId) {
-                example.messageId = metadata.messageId;
-            }
-
-            if (sourceFiles.context) {
-                example.context = evalContext(sourceFiles.context);
-            }
-
+            // Transform a React example's JSX.
             if (sourceFiles.component) {
                 example.getComponent = wrapComponent(sourceFiles.component);
             }
@@ -113,7 +107,7 @@ function getMetadata(type, name) {
             return yaml.safeLoad(contents);
         }, function (err) {
             // Surpress error, okay if an example doesn't have a meta.yaml file.
-            return null;
+            return {};
         });
 }
 
@@ -153,14 +147,6 @@ function getSourceFiles(type, name) {
         default:
             throw new Error('Unsupported example type: ' + type);
     }
-}
-
-function evalContext(source) {
-    // Why? Oh! Why!?
-    // Ah yes, because we're normalizing template engines
-    /*jslint evil: true*/
-    return (new Function(source + '\nreturn context;'))();
-    /*jslint evil: false*/
 }
 
 function wrapComponent(jsxSource) {

--- a/shared/components/dust-example.jsx
+++ b/shared/components/dust-example.jsx
@@ -54,11 +54,11 @@ export default React.createClass({
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (example.messageId) {
+        if (example.meta.messageId) {
             tabs.splice(1, 0,
                 <Tab label="Message" key="message">
                     <CodeBlock>
-                        {messages[example.messageId]}
+                        {messages[example.meta.messageId]}
                     </CodeBlock>
                 </Tab>
             );
@@ -81,7 +81,7 @@ export default React.createClass({
                         formats={this.props.intl.formats}
                         messages={messages}
                         source={example.source.template}
-                        context={example.context} />
+                        context={this.evalContext(example.source.context)} />
 
                     <div className="example-output-controls">
                         <label>

--- a/shared/components/handlebars-example.jsx
+++ b/shared/components/handlebars-example.jsx
@@ -54,11 +54,11 @@ export default React.createClass({
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (example.messageId) {
+        if (example.meta.messageId) {
             tabs.splice(1, 0,
                 <Tab label="Message" key="message">
                     <CodeBlock>
-                        {messages[example.messageId]}
+                        {messages[example.meta.messageId]}
                     </CodeBlock>
                 </Tab>
             );
@@ -80,7 +80,7 @@ export default React.createClass({
                         formats={intl.formats}
                         messages={messages}
                         source={example.source.template}
-                        context={example.context} />
+                        context={this.evalContext(example.source.context)} />
 
                     <div className="example-output-controls">
                         <label>

--- a/shared/components/react-example.jsx
+++ b/shared/components/react-example.jsx
@@ -29,13 +29,13 @@ export default React.createClass({
         var ExampleComponent = example.getComponent();
 
         var tabs = [
-            <Tab label="Component">
+            <Tab label="Component" key="component">
                 <CodeBlock lang="js">
                     {example.source.component}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Render">
+            <Tab label="Render" key="render">
                 <CodeBlock lang="javascript">
                     {this.genderateRenderCode()}
                 </CodeBlock>
@@ -43,11 +43,11 @@ export default React.createClass({
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (example.messageId) {
+        if (example.meta.messageId) {
             tabs.splice(1, 0,
                 <Tab label="Message" key="message">
                     <CodeBlock>
-                        {messages[example.messageId]}
+                        {messages[example.meta.messageId]}
                     </CodeBlock>
                 </Tab>
             );

--- a/shared/mixins/example.js
+++ b/shared/mixins/example.js
@@ -13,7 +13,6 @@ export default {
                 component: React.PropTypes.string
             }),
 
-            context     : React.PropTypes.object,
             getComponent: React.PropTypes.func
         }),
 
@@ -29,6 +28,18 @@ export default {
         return {
             currentLocale: this.props.intl.locales[0]
         };
+    },
+
+    evalContext: function (contextSource) {
+        if (contextSource) {
+            // Why? Oh! Why!?
+            // Ah yes, because we're normalizing template engines
+            /*jslint evil: true*/
+            return (new Function(contextSource + '\nreturn context;'))();
+            /*jslint evil: false*/
+        }
+
+        return {};
     },
 
     updateLocale: function (newLocale) {


### PR DESCRIPTION
This solves issues where the context was "stale", and the live rendering didn't make much sense.
