### PR TITLE
Add support for custom formats in examples

### DIFF
--- a/lib/examples.js
+++ b/lib/examples.js
@@ -107,6 +107,7 @@ function getMetadata(type, name) {
             return yaml.safeLoad(contents);
         }, function (err) {
             // Surpress error, okay if an example doesn't have a meta.yaml file.
+            // Simply return an empty object.
             return {};
         });
 }

--- a/middleware/intl.js
+++ b/middleware/intl.js
@@ -29,7 +29,6 @@ module.exports = function (req, res, next) {
 
             locales : [locale],
             messages: messages
-            // TODO: Handle/merge and Expose the common formats.
         });
 
         res.expose(intlData, 'intl');

--- a/shared/components/dust-example.jsx
+++ b/shared/components/dust-example.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
         renderCode: [
             'context.intl = intlData;',
             'dust.render(template, context, function(err, html) {',
-            '    ...put `html` into the DOM or use it otherwise...',
+            '    // Put `html` into the DOM or use it otherwise...',
             '});'
         ].join('\n')
     },
@@ -78,7 +78,7 @@ export default React.createClass({
                     <DustOutput
                         exampleId={this.props.example.id}
                         locales={currentLocale}
-                        formats={this.props.intl.formats}
+                        formats={example.meta.formats}
                         messages={messages}
                         source={example.source.template}
                         context={this.evalContext(example.source.context)} />

--- a/shared/components/handlebars-example.jsx
+++ b/shared/components/handlebars-example.jsx
@@ -77,7 +77,7 @@ export default React.createClass({
 
                     <HandlebarsOutput
                         locales={currentLocale}
-                        formats={intl.formats}
+                        formats={example.meta.formats}
                         messages={messages}
                         source={example.source.template}
                         context={this.evalContext(example.source.context)} />

--- a/shared/components/react-example.jsx
+++ b/shared/components/react-example.jsx
@@ -10,14 +10,24 @@ export default React.createClass({
     displayName: 'ReactExample',
     mixins     : [ExampleMixin],
 
+    statics: {
+        renderCode: [
+            'React.renderComponent(',
+            '    <Component ' +
+                    'locales={intlData.locales} ' +
+                    'formats={intlData.formats} ' +
+                    'messages={intlData.messages} />',
+            '    document.getElementById("example")',
+            ');'
+        ].join('\n')
+    },
+
     genderateRenderCode: function () {
         return [
             '/** @jsx React.DOM */',
-            'React.renderComponent(',
-            '    <Component locales={[\'' + this.state.currentLocale + '\']} ' +
-                    'formats={…} messages={…} />',
-            '    document.getElementById(\'example\')',
-            ');'
+            this.generateIntlDataCode(),
+            '',
+            this.constructor.renderCode
         ].join('\n');
     },
 
@@ -67,7 +77,7 @@ export default React.createClass({
                     <div className="react-output">
                         <ExampleComponent
                             locales={currentLocale}
-                            formats={this.props.intl.formats}
+                            formats={example.meta.formats}
                             messages={messages} />
                     </div>
 

--- a/shared/mixins/example.js
+++ b/shared/mixins/example.js
@@ -6,22 +6,24 @@ export default {
             id  : React.PropTypes.string.isRequired,
             name: React.PropTypes.string.isRequired,
             type: React.PropTypes.string.isRequired,
+            meta: React.PropTypes.object.isRequired,
 
             source: React.PropTypes.shape({
                 template : React.PropTypes.string,
                 context  : React.PropTypes.string,
                 component: React.PropTypes.string
-            }),
+            }).isRequired,
 
+            // Optional.
             getComponent: React.PropTypes.func
-        }),
+        }).isRequired,
 
         intl: React.PropTypes.shape({
             availableLocales: React.PropTypes.array.isRequired,
 
             locales : React.PropTypes.array.isRequired,
             messages: React.PropTypes.object.isRequired
-        })
+        }).isRequired
     },
 
     getInitialState: function () {
@@ -47,12 +49,23 @@ export default {
     },
 
     generateIntlDataCode: function () {
-        return [
-            'var intlData = {',
-            '    locales : \'' + this.state.currentLocale + '\',',
-            '    formats : {…},',
-            '    messages: {…}',
-            '};'
-        ].join('\n');
+        var currentLocale = this.state.currentLocale;
+        var formats       = this.props.example.meta.formats || {};
+        var messages      = this.props.intl.messages[currentLocale];
+        var messageId     = this.props.example.meta.messageId;
+        var message       = messages[messageId];
+
+        messages = {};
+        if (message) {
+            messages[messageId] = message;
+        }
+
+        var intlData = {
+            locales : currentLocale,
+            formats : formats,
+            messages: messages
+        };
+
+        return 'var intlData = ' + JSON.stringify(intlData, null, 4) + ';';
     }
 };


### PR DESCRIPTION
This adds the ability to add custom `formats` in the examples by simply adding an `meta.yaml` file to the example with something like this:

``` yml
formats:
  date:
    timeStyle:
      hour: numeric
      minute: numeric

  number:
    percentStyle:
      style: percent
```

This also improves the "Render" tab by actually outputting the `formats` and `messages` used by the example.
