### PR TITLE
Add docs on how to load locale data

### DIFF
--- a/lib/package-meta.js
+++ b/lib/package-meta.js
@@ -12,7 +12,8 @@ module.exports = function (pkgName) {
 
         dist: {
             main       : path.join(pkg.name, 'dist', pkg.name + '.min.js'),
-            withLocales: path.join(pkg.name, 'dist', pkg.name + '-with-locales.min.js')
+            withLocales: path.join(pkg.name, 'dist', pkg.name + '-with-locales.min.js'),
+            localeData : path.join(pkg.name, 'dist', 'locale-data')
         }
     };
 };

--- a/views/pages/dust.hbs
+++ b/views/pages/dust.hbs
@@ -93,16 +93,21 @@ dust.renderSource(template, context, function(error, html) {
 
     <h3 id="install-browser">Browser</h3>
 
-    <h4>1. Load the scripts onto your page</h4>
+    <h4>1. Load the Scripts onto the Page</h4>
+
+    <p>
+        First, load Dust and Dust Intl onto the page:
+    </p>
 
 {{#code "html"}}
 <script src="dustjs-linkedin/dist/dust-full.min.js"></script>
 <script src="{{package.dist.main}}"></script>
 {{/code}}
 
+    {{> integrations/load-locale-data-browser}}
     {{> integrations/note-intl-browser}}
 
-    <h4>2. Register the helpers</h4>
+    <h4>2. Register the Helpers</h4>
 
 {{#code "js"}}
 DustIntl.registerWith(dust);
@@ -110,7 +115,7 @@ DustIntl.registerWith(dust);
 
     <h3 id="install-node">Node/CommonJS</h3>
 
-    <h4>1. Require the module</h4>
+    <h4>1. Require the Module</h4>
 
 {{#code "js"}}
 // Load and use polyfill for ECMA-402.
@@ -122,9 +127,10 @@ var dust     = require('dustjs-linkedin');
 var DustIntl = require('dust-intl');
 {{/code}}
 
+    {{> integrations/load-locale-data-node}}
     {{> integrations/note-intl-node}}
 
-    <h4>2. Register the helpers</h4>
+    <h4>2. Register the Helpers</h4>
 
 {{#code "js"}}
 DustIntl.registerWith(dust);

--- a/views/pages/handlebars.hbs
+++ b/views/pages/handlebars.hbs
@@ -97,16 +97,21 @@ var html = template(context, {
 
     <h3 id="install-browser">Browser</h3>
 
-    <h4>1. Load the scripts onto your page</h4>
+    <h4>1. Load the Scripts onto the Page</h4>
+
+    <p>
+        First, load Handlebars and Handlebars Intl onto the page:
+    </p>
 
 {{#code "html"}}
 <script src="handlebars/dist/handlebars.min.js"></script>
 <script src="{{package.dist.main}}"></script>
 {{/code}}
 
+    {{> integrations/load-locale-data-browser}}
     {{> integrations/note-intl-browser}}
 
-    <h4>2. Register the helpers</h4>
+    <h4>2. Register the Helpers</h4>
 
 {{#code "js"}}
 HandlebarsIntl.registerWith(Handlebars);
@@ -114,7 +119,7 @@ HandlebarsIntl.registerWith(Handlebars);
 
     <h3 id="install-node">Node/CommonJS</h3>
 
-    <h4>1. Require the module</h4>
+    <h4>1. Require the Module</h4>
 
 {{#code "js"}}
 // Load and use polyfill for ECMA-402.
@@ -126,9 +131,10 @@ var Handlebars     = require('handlebars');
 var HandlebarsIntl = require('handlebars-intl');
 {{/code}}
 
+    {{> integrations/load-locale-data-node}}
     {{> integrations/note-intl-node}}
 
-    <h4>2. Register the helpers</h4>
+    <h4>2. Register the Helpers</h4>
 
 {{#code "js"}}
 HandlebarsIntl.registerWith(Handlebars);

--- a/views/pages/react.hbs
+++ b/views/pages/react.hbs
@@ -102,16 +102,21 @@ React.renderComponent(
 
     <h3 id="install-browser">Browser</h3>
 
-    <h4>1. Load the scripts onto your page</h4>
+    <h4>1. Load the Scripts onto the Page</h4>
+
+    <p>
+        First, load React and React Intl onto the page:
+    </p>
 
 {{#code "html"}}
 <script src="react/dist/react.min.js"></script>
 <script src="{{package.dist.main}}"></script>
 {{/code}}
 
+    {{> integrations/load-locale-data-browser}}
     {{> integrations/note-intl-browser}}
 
-    <h4>2. Use <code>ReactIntlMixin</code> in a React component</h4>
+    <h4>2. Use <code>ReactIntlMixin</code> in a React Component</h4>
 
 {{#code "js"}}
 var MyComponent = React.createClass({
@@ -122,7 +127,7 @@ var MyComponent = React.createClass({
 
     <h3 id="install-node">Node/CommonJS</h3>
 
-    <h4>1. Require the module</h4>
+    <h4>1. Require the Module</h4>
 
 {{#code "js"}}
 // Load and use polyfill for ECMA-402.
@@ -134,9 +139,10 @@ var React          = require('react');
 var ReactIntlMixin = require('react-intl');
 {{/code}}
 
+    {{> integrations/load-locale-data-node}}
     {{> integrations/note-intl-node}}
 
-    <h4>2. Use ReactIntlMixin in a React component</h4>
+    <h4>2. Use ReactIntlMixin in a React Component</h4>
 
 {{#code "js"}}
 var MyComponent = React.createClass({

--- a/views/partials/integrations/load-locale-data-browser.hbs
+++ b/views/partials/integrations/load-locale-data-browser.hbs
@@ -1,0 +1,11 @@
+<p>
+    By default, <code>{{package.name}}</code> ships with the locale data for English built-in to the library's runtime. When you need to format data in another locale, include its data; e.g., for French:
+</p>
+
+{{#code "html"}}
+<script src="{{package.dist.localeData}}/fr.js"></script>
+{{/code}}
+
+<p>
+    All 150+ languages supported by this library use their root BCP 47 langage tag; i.e., the part before the first hyphen (if any).
+</p>

--- a/views/partials/integrations/load-locale-data-node.hbs
+++ b/views/partials/integrations/load-locale-data-node.hbs
@@ -1,0 +1,3 @@
+<p>
+    In Node.js, the data for all 150+ languages is pre-loaded and does not need to be loaded manually.
+</p>

--- a/views/partials/integrations/note-intl-browser.hbs
+++ b/views/partials/integrations/note-intl-browser.hbs
@@ -1,3 +1,3 @@
 <p class="note">
-    <strong>Note:</strong> Older browsers and Safari do not provide the global {{code "Intl"}} object (ECMA-402). Read more on <a href="{{pathTo 'guide'}}#how-to-patch">how to patch the browser</a> using a polyfill.
+    <strong>Note:</strong> Older browsers and Safari do not provide the global {{code "Intl"}} object (ECMA-402). Read more on <a href="{{pathTo 'guide'}}#patch-runtime">how to patch the browser runtime</a> using a polyfill.
 </p>

--- a/views/partials/integrations/note-intl-node.hbs
+++ b/views/partials/integrations/note-intl-node.hbs
@@ -1,3 +1,3 @@
 <p class="note">
-    <strong>Note:</strong> Node.js (as of 0.10) doesn't provide the global <code>Intl</code> object (ECMA-402).Read more on <a href="{{pathTo 'guide'}}#how-to-patch">how to patch Node.js</a> using a polyfill.
+    <strong>Note:</strong> Node.js (as of 0.10) doesn't provide the global <code>Intl</code> object (ECMA-402).Read more on <a href="{{pathTo 'guide'}}#patch-runtime">how to patch Node.js</a> using a polyfill.
 </p>


### PR DESCRIPTION
This adds back the docs on how to load the locale data onto the page for each integration.

Closes #121
