### PR TITLE
Fix TOC component's `maxDepth` comparison

### DIFF
--- a/shared/components/table-of-contents.jsx
+++ b/shared/components/table-of-contents.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
             anchor = <a href={'#' + header.id}>{header.textContent}</a>;
             section = header.parentNode;
             childHeaders = section.querySelectorAll(this.selectors[nextSelector]);
-            if (childHeaders.length > 0 && nextSelector <= maxDepth) {
+            if (childHeaders.length > 0 && nextSelector < maxDepth) {
                 data.push(
                     <li>
                         {anchor}


### PR DESCRIPTION
This changes the interpretation of the TOC component's `maxDepth`. A `maxDepth = 2`, should mean two levels of headings in the TOC, not three.

This also reduces the number of levels shown on the Guide page to two levels, like @caridy suggested.
