### PR TITLE
Fix known blank page issue in Safari

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ app.use(middleware.slash());
 
 var route = router.route.bind(router);
 
+router.use(middleware.fixBadSafari);
 router.use(middleware.intl);
 
 routes.home(route('/'));

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -7,6 +7,7 @@ exports = module.exports = utils.requireDir(__dirname);
 exports.compress     = require('compression');
 exports.errorHandler = require('errorhandler');
 exports.favicon      = require('serve-favicon');
+exports.fixBadSafari = require('jumanji');
 exports.logger       = require('morgan');
 exports.slash        = require('express-slash');
 exports.static       = require('serve-static');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "handlebars-intl": "^1.0.0",
     "intl": "^0.1.4",
     "js-yaml": "^3.2.1",
+    "jumanji": "^0.1.1",
     "morgan": "^1.2.3",
     "nodeify": "^1.0.0",
     "react": "^0.11.1",


### PR DESCRIPTION
There's been a weird edge-case caching issue with Express apps ever since Safari 7 where users can see blank pages.

This change adds the "jumanji" dependency to fix the issue. Details about the issue are in its README: 
https://github.com/Dakuan/jumanji

**Note:** We have to wait for `jumanji` to be approved/whitelisted before we can merge this PR.
