### PR TITLE
Fix punctuation error

### DIFF
--- a/views/pages/home.hbs
+++ b/views/pages/home.hbs
@@ -172,7 +172,7 @@
 
         <div class="standards-content">
             <p class="standards-desc">
-                {{brand}} is aligned with: <a href="http://www.ecma-international.org/ecma-402/1.0/">ECMAScript Internationalization API</a> (ECMA-402), <a href="http://cldr.unicode.org/">Unicode CLDR</a>, and <a href="http://userguide.icu-project.org/formatparse/messages">ICU Message syntax</a>. By building on these industry standards, {{brand}} leverages APIs in modern browsers, and works with the message syntax used by professional translators.
+                {{brand}} is aligned with: <a href="http://www.ecma-international.org/ecma-402/1.0/">ECMAScript Internationalization API</a> (ECMA-402), <a href="http://cldr.unicode.org/">Unicode CLDR</a>, and <a href="http://userguide.icu-project.org/formatparse/messages">ICU Message syntax</a>. By building on these industry standards, {{brand}} leverages APIs in modern browsers and works with the message syntax used by professional translators.
             </p>
 
             <p class="standards-logo">


### PR DESCRIPTION
A comma should only be used with a conjunction when it's joining two independent clauses.
