### PR TITLE
[experimental] improves sourcemap

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -74,7 +74,12 @@ var img = new Funnel('public/img/', {
     destDir: '/img'
 });
 
-var intlIntegrations = compileModules('public/intl/', {
+var intl = new Funnel('public/intl/', {
+    srcDir : '/',
+    destDir: '/intl'
+});
+
+intl = compileModules(intl, {
     description: 'VendorModules',
     formatter  : 'bundle',
     output     : '/intl/integrations.js',
@@ -99,7 +104,7 @@ localeData = concatTrees(localeData, {
     outputFile: '/intl/locale-data.js'
 });
 
-var intl = mergeTrees([intlIntegrations, localeData]);
+intl = mergeTrees([intl, localeData]);
 
 var js = new Funnel('public/js/', {
     srcDir : '/',

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ if (app.get('env') === 'development') {
 
 app.use(middleware.compress());
 app.use(middleware.favicon(path.join('./public/favicon.ico')));
-app.use(middleware.static(path.join(config.dirs.build, 'client'), {maxage: '1m'}));
+app.use('/build', middleware.static(path.join(config.dirs.build, 'client'), {maxage: '1m'}));
 app.use(router);
 app.use(middleware.slash());
 

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -9,7 +9,7 @@
 
     {{> purecss}}
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/build/css/style.css">
 
     {{> analytics}}
 </head>
@@ -26,7 +26,7 @@
     {{> intl-integrations}}
     {{> syntax-highlighting}}
 
-    <script src="/js/app.js"></script>
+    <script src="/build/js/app.js"></script>
 
 </body>
 </html>

--- a/views/partials/intl-integrations.hbs
+++ b/views/partials/intl-integrations.hbs
@@ -1,2 +1,2 @@
-<script src="/intl/integrations.js"></script>
-<script src="/intl/locale-data.js"></script>
+<script src="/build/intl/integrations.js"></script>
+<script src="/build/intl/locale-data.js"></script>

--- a/views/partials/polyfills.hbs
+++ b/views/partials/polyfills.hbs
@@ -1,6 +1,6 @@
-<script src="/vendor/intl/Intl{{min}}.js"></script>
+<script src="/build/vendor/intl/Intl{{min}}.js"></script>
 {{#each @intl.availableLocales}}
-<script src="/vendor/intl/locale-data/jsonp/{{this}}.js"></script>
+<script src="/build/vendor/intl/locale-data/jsonp/{{this}}.js"></script>
 {{/each}}
 
-<script src="/vendor/es6-shim/es6-shim{{min}}.js"></script>
+<script src="/build/vendor/es6-shim/es6-shim{{min}}.js"></script>

--- a/views/partials/syntax-highlighting.hbs
+++ b/views/partials/syntax-highlighting.hbs
@@ -1,5 +1,5 @@
-<script src="/vendor/rainbow/rainbow{{min}}.js"></script>
-<script src="/vendor/rainbow/language/generic.js"></script>
-<script src="/vendor/rainbow/language/html.js"></script>
-<script src="/vendor/rainbow/language/javascript.js"></script>
-<link rel="stylesheet" href="/css/syntax.css">
+<script src="/build/vendor/rainbow/rainbow{{min}}.js"></script>
+<script src="/build/vendor/rainbow/language/generic.js"></script>
+<script src="/build/vendor/rainbow/language/html.js"></script>
+<script src="/build/vendor/rainbow/language/javascript.js"></script>
+<link rel="stylesheet" href="/build/css/syntax.css">

--- a/views/partials/template-engines.hbs
+++ b/views/partials/template-engines.hbs
@@ -1,3 +1,3 @@
-<script src="/vendor/react/react-with-addons{{min}}.js"></script>
-<script src="/vendor/handlebars/handlebars{{min}}.js"></script>
-<script src="/vendor/dust/dust-full{{min}}.js"></script>
+<script src="/build/vendor/react/react-with-addons{{min}}.js"></script>
+<script src="/build/vendor/handlebars/handlebars{{min}}.js"></script>
+<script src="/build/vendor/dust/dust-full{{min}}.js"></script>


### PR DESCRIPTION
- uses /build static folder to differentiate transpiled files from source files in devtool
- reorg folders when building with broccoli

@ericf this is what I have locally after our conversation, feel free to take over this one once we merge https://github.com/esnext/es6-module-transpiler/pull/183
