### PR TITLE
Tweak splash example controls style

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -356,8 +356,12 @@ li code {
 }
 .splash-example-controls {
     display: flex;
+    justify-content: flex-end;
     align-items: baseline;
     margin-top: 0.25rem;
+}
+.splash-example-control:first-child {
+    margin-right: 0.25rem;
 }
 .splash-example-controls,
 .splash-example-controls a:link,
@@ -628,9 +632,6 @@ li code {
         width: 12.3436rem;
         height: 3rem;
     }
-    .splash-example-controls {
-        justify-content: space-between;
-    }
     .splash-example-output {
         font-size: 1.25rem;
     }
@@ -731,13 +732,6 @@ li code {
     .nav-menu-item {
         margin-left: 0.25rem;
         margin-right: 0.25rem;
-    }
-
-    .splash-example-controls {
-        justify-content: flex-end;
-    }
-    .splash-example-control:first-child {
-        margin-right: 1rem;
     }
 
     .legal {


### PR DESCRIPTION
The splash example controls seems to breaks on Chrome v40+. Currently, it switches `justify-content` property by using media queries, but I don't feel to need it because it can be maintained looks without that switching. This issue resolves by this change.

I confirmed it works on following browsers.
- Chrome v39 (stable)
- Chrome v40 (beta)
- Chrome v41 (canary)
- Firefox v34 (stable)
- Firefox v36 (Developer Edition)
- Safari v8 (OS X Yosemite)
- Safari v8 (iOS on iPhone 5s)
- Opera v26 (stable)

![2014-12-13 at 18 57](https://cloud.githubusercontent.com/assets/34588/5423325/10273f58-82fa-11e4-88f0-282bc10082fd.png)
