### PR TITLE
Include locale data for each integration

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -59,17 +59,34 @@ var formatjsIntegrations = compileModules('public/vendor/formatjs/', {
     ]
 });
 
-var formatjsLocaleData = new Funnel(node_modules, {
-    srcDir : 'react-intl/dist/locale-data',
-    destDir: '/',
-
-    files: config.availableLocales.map(function (locale) {
-        return locale.split('-')[0] + '.js';
-    })
+var localeDataFiles = config.availableLocales.map(function (locale) {
+    return locale.split('-')[0] + '.js';
 });
 
-formatjsLocaleData = concatTrees(formatjsLocaleData, {
-    inputFiles: ['*.js'],
+var dustIntlLocaleData = new Funnel(node_modules, {
+    srcDir : 'dust-intl/dist/locale-data',
+    destDir: 'dust-intl/',
+    files  : localeDataFiles
+});
+
+var handlebarsIntlLocaleData = new Funnel(node_modules, {
+    srcDir : 'handlebars-intl/dist/locale-data',
+    destDir: 'handlebars-intl/',
+    files  : localeDataFiles
+});
+
+var reactIntlLocaleData = new Funnel(node_modules, {
+    srcDir : 'react-intl/dist/locale-data',
+    destDir: 'react-intl/',
+    files  : localeDataFiles
+});
+
+var formatjsLocaleData = concatTrees(mergeTrees([
+    dustIntlLocaleData,
+    handlebarsIntlLocaleData,
+    reactIntlLocaleData
+]), {
+    inputFiles: ['*/*.js'],
     outputFile: '/vendor/formatjs/locale-data.js'
 });
 

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -59,33 +59,25 @@ var formatjsIntegrations = compileModules('public/vendor/formatjs/', {
     ]
 });
 
+// Create list of locale data filenames for all of the locales the app supports,
+// which is a small subset of all the locales Format.js libs support.
 var localeDataFiles = config.availableLocales.map(function (locale) {
     return locale.split('-')[0] + '.js';
 });
 
-var dustIntlLocaleData = new Funnel(node_modules, {
-    srcDir : 'dust-intl/dist/locale-data',
-    destDir: 'dust-intl/',
-    files  : localeDataFiles
-});
+var formatjsLocaleData = mergeTrees([
+    'dust-intl',
+    'handlebars-intl',
+    'react-intl'
+].map(function (integration) {
+    return new Funnel(node_modules, {
+        srcDir : integration + '/dist/locale-data',
+        destDir: integration,
+        files  : localeDataFiles
+    });
+}));
 
-var handlebarsIntlLocaleData = new Funnel(node_modules, {
-    srcDir : 'handlebars-intl/dist/locale-data',
-    destDir: 'handlebars-intl/',
-    files  : localeDataFiles
-});
-
-var reactIntlLocaleData = new Funnel(node_modules, {
-    srcDir : 'react-intl/dist/locale-data',
-    destDir: 'react-intl/',
-    files  : localeDataFiles
-});
-
-var formatjsLocaleData = concatTrees(mergeTrees([
-    dustIntlLocaleData,
-    handlebarsIntlLocaleData,
-    reactIntlLocaleData
-]), {
+formatjsLocaleData = concatTrees(formatjsLocaleData, {
     inputFiles: ['*/*.js'],
     outputFile: '/vendor/formatjs/locale-data.js'
 });


### PR DESCRIPTION
This updates the Broccoli build to include the locale data for each integration. Doing this makes sure that if the lib's deps get out of sync that they all still propagate the locale data down to the copy of `IntlMessageFormat` and `IntlRelativeFormat` they depend on.

This adds bulk to the `locale-data.js` file that's created, but it's **highly** compressible with gzip since the data is all duplicated.