### PR TITLE
Expose React components on their DOM nodes

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -4,9 +4,11 @@ import SplashExample from '../components/splash-example';
 
 export default function init(state) {
     var splashProps = Object.assign({}, state.intl, state.examples.splash);
+    var node        = document.querySelector('.splash-example-container');
 
-    React.render(
+    // Expose React component on its DOM node for testing.
+    node.component = React.render(
         React.createElement(SplashExample, splashProps),
-        document.querySelector('.splash-example-container')
+        node
     );
 }

--- a/public/js/integration.js
+++ b/public/js/integration.js
@@ -20,7 +20,8 @@ function hydrateExample(id, type, props) {
 
     var ExampleComponent = getExampleComponent(type);
 
-    React.render(
+    // Expose React component on its DOM node for testing.
+    exampleNode.component = React.render(
         React.createElement(ExampleComponent, props),
         exampleNode.parentNode
     );


### PR DESCRIPTION
This exposes the React component instances on their DOM nodes to make it easier to test the site. The React components are now accessible via a `component` expando property added to every root DOM node that `React.render()` is passed.

Browser testing can access these components and do things like call `setProps()` or `setState()` on them.

/cc @jlecomte 