### PR TITLE
Pointing build status to #master instead of last run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FormatJS
 ========
 
-[![Build Status](http://img.shields.io/travis/yahoo/formatjs-site.svg?style=flat-square)](https://travis-ci.org/yahoo/formatjs-site)
+[![Build Status](https://img.shields.io/travis/yahoo/formatjs-site/master.svg?style=flat-square)](https://travis-ci.org/yahoo/formatjs-site)
 [![Dependency Status](http://img.shields.io/gemnasium/yahoo/formatjs-site.svg?style=flat-square)](https://gemnasium.com/yahoo/formatjs-site)
 
 Website for Yahoo's JavaScript internationalization suite.


### PR DESCRIPTION
Because the last Travis build failed, by the upgrade branch, it's showing build fail on the README.