### PR TITLE
Remove reference to Ember from features partial

### DIFF
--- a/views/partials/integrations/features.hbs
+++ b/views/partials/integrations/features.hbs
@@ -12,6 +12,6 @@
         Supports custom formatters for <strong>numbers</strong> and <strong>dates/times</strong>.
     </li>
     <li>
-        Access to <code>this.intl</code> API throughout your Ember application.
+        Access to <code>this.intl</code> API throughout your application.
     </li>
 </ul>

--- a/views/partials/integrations/features.hbs
+++ b/views/partials/integrations/features.hbs
@@ -11,7 +11,4 @@
     <li>
         Supports custom formatters for <strong>numbers</strong> and <strong>dates/times</strong>.
     </li>
-    <li>
-        Access to <code>this.intl</code> API throughout your application.
-    </li>
 </ul>


### PR DESCRIPTION
The reference to Ember is removed because this partial is rendered on pages for frameworks other than Ember (React, Duct, etc.)