### PR TITLE
Hack Istanbul to ignore es6-shim

### DIFF
--- a/lib/package-meta.js
+++ b/lib/package-meta.js
@@ -2,8 +2,6 @@
 
 var path = require('path');
 
-require('es6-shim');
-
 module.exports = function (pkgName, options) {
     var pkg = require(path.join(pkgName, 'package.json'));
 
@@ -15,6 +13,7 @@ module.exports = function (pkgName, options) {
         version    : pkg.version,
         description: pkg.description,
         hasDownload: true,
+
         dist: {
             main       : path.join(distPath, pkg.name + '.min.js'),
             withLocales: path.join(distPath, pkg.name + '-with-locales.min.js'),

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "postinstall": "grunt",
-    "test": "istanbul cover -- node_modules/mocha/bin/_mocha tests/unit/ --reporter spec",
+    "test": "istanbul cover --post-require-hook ./tests/istanbul-hook -- _mocha tests/unit/ -r es6-shim --reporter spec",
     "start": "node server.js"
   },
   "repository": {

--- a/tests/istanbul-hook.js
+++ b/tests/istanbul-hook.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var path     = require('path');
+var istanbul = require('istanbul');
+
+// Set of files we want Istanbul to _really_ ignore.
+var IGNORE_FILES = [
+    './node_modules/es6-shim/es6-shim.js'
+];
+
+// Override Istanbul's `require()` hook, so that certain modules, like
+// polyfills, can be _really_ ignored from Istanbul coverage numbers.
+var istanbulRequireHook = istanbul.hook.hookRequire;
+istanbul.hook.hookRequire = function (matcher, transformer, options) {
+    var ignoreFiles = IGNORE_FILES.reduce(function (hash, filename) {
+        hash[path.resolve(filename)] = true;
+        return hash;
+    }, {});
+
+    istanbulRequireHook(matcher, function (code, filename) {
+        if (ignoreFiles[filename]) {
+            console.log('Ignoring from code coverage: %s', filename);
+            return code;
+        }
+
+        return transformer(code, filename);
+    }, options);
+};
+
+// Satisfy post-require-hook interface.
+module.exports = function () {};

--- a/tests/unit/lib.helpers.js
+++ b/tests/unit/lib.helpers.js
@@ -131,8 +131,6 @@ describe('Helpers', function () {
                 }
             });
         });
-
-
     });
 
     describe('cdnUrl', function () {


### PR DESCRIPTION
Istanbul was instrumenting the `es6-shim` module because it's a polyfill that provides global functions which are invoked by the unit tests.

I was unable to configure Istanbul to ignore this file, so I had to misuse the `--post-require-hook` CLI option to load this "patch". The hack takes control of `istanbul.hook.hookRequire` to opt-out of transformation if a file matches one of the ignored files.