### PR TITLE
Replace Example mixin with composable components

### DIFF
--- a/lib/examples.js
+++ b/lib/examples.js
@@ -5,9 +5,9 @@ var path         = require('path');
 var transformJSX = require('react-tools').transform;
 var yaml         = require('js-yaml');
 
-var config          = require('../config');
-var utils           = require('./utils');
-var renderComponent = require('../lib/component').render;
+var config    = require('../config');
+var utils     = require('./utils');
+var component = require('../lib/component');
 
 exports.get    = getExamples;
 exports.render = renderExamples;
@@ -53,9 +53,10 @@ function renderExamples(examples, intl) {
     }
 
     return examples.reduce(function (hash, example) {
-        hash[example.name] = renderComponent(example.type + '-example', {
-            example: example,
-            intl   : intl
+        hash[example.name] = component.render('example-container', {
+            component: component.require(example.type + '-example'),
+            example  : example,
+            intl     : intl
         });
 
         return hash;

--- a/public/js/home.jsx
+++ b/public/js/home.jsx
@@ -7,7 +7,7 @@ export default function init(state) {
     var containerNode = document.querySelector('.splash-example-container');
 
     // Expose React component on its DOM node for testing.
-    node.component = React.render(
+    containerNode.component = React.render(
         <SplashExample {...splashProps} />,
         containerNode
     );

--- a/public/js/home.jsx
+++ b/public/js/home.jsx
@@ -3,12 +3,12 @@
 import SplashExample from './components/splash-example';
 
 export default function init(state) {
-    var splashProps = Object.assign({}, state.intl, state.examples.splash);
-    var node        = document.querySelector('.splash-example-container');
+    var splashProps   = Object.assign({}, state.intl, state.examples.splash);
+    var containerNode = document.querySelector('.splash-example-container');
 
     // Expose React component on its DOM node for testing.
     node.component = React.render(
         <SplashExample {...splashProps} />,
-        node
+        containerNode
     );
 }

--- a/public/js/integration.jsx
+++ b/public/js/integration.jsx
@@ -1,11 +1,12 @@
 /* global React */
 
+import ExampleContainer from './components/example-container';
 import HandlebarsExample from './components/handlebars-example';
 import ReactExample from './components/react-example';
 import DustExample from './components/dust-example';
 import EmberExample from './components/ember-example';
 
-var COMPONENTS = {
+var INTEGRATION_COMPONENTS = {
     handlebars: HandlebarsExample,
     react     : ReactExample,
     dust      : DustExample,
@@ -25,13 +26,11 @@ function hydrateExample(id, type, props) {
     var exampleNode = document.getElementById(id);
     if (!exampleNode) { return; }
 
-    var ExampleComponent = COMPONENTS[type];
-    if (!ExampleComponent) {
-        throw new Error('No output component for type: ' + type);
-    }
+    var ExampleComponent = INTEGRATION_COMPONENTS[type];
+    var containerNode    = exampleNode.parentNode;
 
-    exampleNode.parentNode.component = React.render(
-        <ExampleComponent {...props} />,
-        exampleNode.parentNode
+    containerNode.component = React.render(
+        <ExampleContainer {...props} component={ExampleComponent} />,
+        containerNode
     );
 }

--- a/shared/components/dust-example.jsx
+++ b/shared/components/dust-example.jsx
@@ -1,101 +1,86 @@
 /* global React */
 
-import ExampleMixin from '../mixins/example';
+import Example from './example';
 import CodeBlock from './code-block';
-import LocaleSelect from './locale-select';
 import DustOutput from './dust-output';
 import {Tabs, Tab} from './tabs';
 
 export default React.createClass({
     displayName: 'DustExample',
-    mixins     : [ExampleMixin],
 
-    statics: {
-        renderCode: [
-            'dust.render(template, context, function(err, html) {',
-            '    // Put `html` into the DOM or use it otherwise...',
-            '});'
-        ].join('\n')
-    },
+    propTypes: {
+        id: React.PropTypes.string.isRequired,
 
-    generateRenderCode: function () {
-        var intlData = this.generateIntlData();
+        source: React.PropTypes.shape({
+            template: React.PropTypes.string.isRequired,
+            context : React.PropTypes.string.isRequired,
+            intlData: React.PropTypes.string.isRequired
+        }).isRequired,
 
-        return [
-            'context.intl = ' + JSON.stringify(intlData, null, 4) + ';',
-            '',
-            this.constructor.renderCode
-        ].join('\n');
+        context : React.PropTypes.object.isRequired,
+        message : React.PropTypes.string,
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object,
+
+        currentLocale   : React.PropTypes.string.isRequired,
+        availableLocales: React.PropTypes.array.isRequired,
+        onLocaleChange  : React.PropTypes.func.isRequired,
     },
 
     render: function () {
-        var example          = this.props.example;
-        var currentLocale    = this.state.currentLocale;
-        var availableLocales = this.state.availableLocales;
-        var messages         = this.props.intl.messages[currentLocale];
-        var message          = messages[example.meta.messageId];
+        var props = this.props;
 
         var tabs = [
-            <Tab label="Template" key="template" id={example.id + "-template"}>
+            <Tab label="Template" key="template" id={`${props.id}-template`}>
                 <CodeBlock lang="dust">
-                    {example.source.template}
+                    {props.source.template}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Context" key="context" id={example.id + "-context"}>
+            <Tab label="Context" key="context" id={`${props.id}-context`}>
                 <CodeBlock lang="javascript">
-                    {example.source.context}
+                    {props.source.context}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Render" key="render" id={example.id + "-render"}>
+            <Tab label="Render" key="render" id={`${props.id}-render`}>
                 <CodeBlock lang="javascript">
-                    {this.generateRenderCode()}
+{`context.intl = ${props.source.intlData};
+
+dust.render(template, context, function (err, html) {
+    // Put \`html\` into the DOM or use it otherwise...
+});`}
                 </CodeBlock>
             </Tab>
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (message) {
+        if (props.message) {
             tabs.splice(1, 0,
-                <Tab label="Message" key="message" id={example.id + "-message"}>
+                <Tab label="Message" key="message" id={`${props.id}-message`}>
                     <CodeBlock highlight={false}>
-                        {message}
+                        {props.message}
                     </CodeBlock>
                 </Tab>
             );
         }
 
         return (
-            <div id={example.id} className="example">
-                <div className="example-source">
-                    <Tabs>
-                        {tabs}
-                    </Tabs>
-                </div>
-
-                <div className="example-output">
-                    <h4 className="example-output-heading">Rendered</h4>
-
+            <Example
+                id={props.id}
+                currentLocale={props.currentLocale}
+                availableLocales={props.availableLocales}
+                onLocaleChange={props.onLocaleChange}
+                source={<Tabs>{tabs}</Tabs>}
+                output={
                     <DustOutput
-                        exampleId={example.id}
-                        locales={currentLocale}
-                        formats={example.meta.formats}
-                        messages={messages}
-                        source={example.source.template}
-                        context={this.evalContext(example.source.context)} />
-
-                    <div className="example-output-controls">
-                        <label>
-                            <span className="example-label">Locale:</span>
-                            <LocaleSelect
-                                availableLocales={availableLocales}
-                                value={currentLocale}
-                                onChange={this.updateLocale} />
-                        </label>
-                    </div>
-                </div>
-            </div>
+                        id={props.id}
+                        locales={props.currentLocale}
+                        formats={props.formats}
+                        messages={props.messages}
+                        source={props.source.template}
+                        context={props.context} />
+                } />
         );
     }
 });

--- a/shared/components/dust-output.jsx
+++ b/shared/components/dust-output.jsx
@@ -4,12 +4,21 @@ export default React.createClass({
     displayName: 'DustOutput',
 
     propTypes: {
+        id: React.PropTypes.string.isRequired,
         source : React.PropTypes.string.isRequired,
-        context: React.PropTypes.object.isRequired
+        context: React.PropTypes.object.isRequired,
+
+        locales : React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.array,
+        ]).isRequired,
+
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object
     },
 
     getInitialState: function () {
-        var tmpl = dust.compile(this.props.source, this.props.exampleId);
+        var tmpl = dust.compile(this.props.source, this.props.id);
         dust.loadSource(tmpl);
         // The state that we have is the compiled template, but alas this is
         // passed through in a side channel (registered inside of dust).
@@ -19,7 +28,7 @@ export default React.createClass({
     componentWillReceiveProps: function (nextProps) {
         var tmpl;
         if (nextProps.source !== this.props.source) {
-            tmpl = dust.compile(nextProps.source, this.props.exampleId);
+            tmpl = dust.compile(nextProps.source, this.props.id);
             dust.loadSource(tmpl);
             // The state that we have is the compiled template, but alas this is
             // passed through in a side channel (registered inside of dust).
@@ -44,7 +53,7 @@ export default React.createClass({
         // are simple (don't reference external resources such as partials).
         nextTick = dust.nextTick;
         dust.nextTick = function(cb) { cb(); };
-        dust.render(this.props.exampleId, context, function(err, out) {
+        dust.render(this.props.id, context, function(err, out) {
             dust.nextTick = nextTick;
             if (!err && out) {
                 html = out;

--- a/shared/components/ember-example.jsx
+++ b/shared/components/ember-example.jsx
@@ -1,93 +1,75 @@
 /* global React */
 
-import ExampleMixin from '../mixins/example';
+import Example from './example';
 import CodeBlock from './code-block';
-import LocaleSelect from './locale-select';
 import EmberOutput from './ember-output';
 import {Tabs, Tab} from './tabs';
 
 export default React.createClass({
     displayName: 'EmberExample',
-    mixins     : [ExampleMixin],
 
-    generateRenderCode: function () {
-        var intlData = this.generateIntlData();
+    propTypes: {
+        id: React.PropTypes.string.isRequired,
 
-        return [
-            'var intlData = ' + JSON.stringify(intlData, null, 4) + ';',
-            '',
-            this.constructor.renderCode
-        ].join('\n');
+        source: React.PropTypes.shape({
+            template: React.PropTypes.string.isRequired,
+            context : React.PropTypes.string.isRequired
+        }).isRequired,
+
+        context : React.PropTypes.object.isRequired,
+        message : React.PropTypes.string,
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object,
+
+        currentLocale   : React.PropTypes.string.isRequired,
+        availableLocales: React.PropTypes.array.isRequired,
+        onLocaleChange  : React.PropTypes.func.isRequired,
     },
 
     render: function () {
-        var example          = this.props.example;
-        var currentLocale    = this.state.currentLocale;
-        var availableLocales = this.state.availableLocales;
-        var messages         = this.props.intl.messages[currentLocale];
-        var message          = messages[example.meta.messageId];
+        var props = this.props;
 
         var tabs = [
-            <Tab label="Template" key="template" id={example.id + "-template"}>
+            <Tab label="Template" key="template" id={`${props.id}-template`}>
                 <CodeBlock lang="handlebars">
-                    {example.source.template}
+                    {props.source.template}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Context" key="context" id={example.id + "-context"}>
+            <Tab label="Context" key="context" id={`${props.id}-context`}>
                 <CodeBlock lang="javascript">
-                    {example.source.context}
-                </CodeBlock>
-            </Tab>,
-
-            <Tab label="Render" key="render" id={example.id + "-render"}>
-                <CodeBlock lang="javascript">
-                    {this.generateRenderCode()}
+                    {props.source.context}
                 </CodeBlock>
             </Tab>
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (message) {
+        if (props.message) {
             tabs.splice(1, 0,
-                <Tab label="Message" key="message" id={example.id + "-message"}>
+                <Tab label="Message" key="message" id={`${props.id}-message`}>
                     <CodeBlock highlight={false}>
-                        {message}
+                        {props.message}
                     </CodeBlock>
                 </Tab>
             );
         }
 
         return (
-            <div id={example.id} className="example">
-                <div className="example-source">
-                    <Tabs>
-                        {tabs}
-                    </Tabs>
-                </div>
-
-                <div className="example-output">
-                    <h4 className="example-output-heading">Rendered</h4>
-
+            <Example
+                id={props.id}
+                currentLocale={props.currentLocale}
+                availableLocales={props.availableLocales}
+                onLocaleChange={props.onLocaleChange}
+                source={<Tabs>{tabs}</Tabs>}
+                output={
                     <EmberOutput
-                        exampleId={example.id}
-                        locales={currentLocale}
-                        formats={example.meta.formats}
-                        messages={messages}
-                        source={example.source.template}
-                        context={this.evalContext(example.source.context)} />
-
-                    <div className="example-output-controls">
-                        <label>
-                            <span className="example-label">Locale:</span>
-                            <LocaleSelect
-                                availableLocales={availableLocales}
-                                value={currentLocale}
-                                onChange={this.updateLocale} />
-                        </label>
-                    </div>
-                </div>
-            </div>
+                        exampleId={props.id}
+                        locales={props.currentLocale}
+                        formats={props.formats}
+                        messages={props.messages}
+                        source={props.source.template}
+                        context={props.context} />
+                } />
         );
     }
 });

--- a/shared/components/ember-example.jsx
+++ b/shared/components/ember-example.jsx
@@ -63,7 +63,7 @@ export default React.createClass({
                 source={<Tabs>{tabs}</Tabs>}
                 output={
                     <EmberOutput
-                        exampleId={props.id}
+                        id={props.id}
                         locales={props.currentLocale}
                         formats={props.formats}
                         messages={props.messages}

--- a/shared/components/ember-output.jsx
+++ b/shared/components/ember-output.jsx
@@ -4,8 +4,17 @@ export default React.createClass({
     displayName: 'EmberOutput',
 
     propTypes: {
-        source: React.PropTypes.string.isRequired,
-        context: React.PropTypes.object.isRequired
+        id     : React.PropTypes.string.isRequired,
+        source : React.PropTypes.string.isRequired,
+        context: React.PropTypes.object.isRequired,
+
+        locales : React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.array,
+        ]).isRequired,
+
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object
     },
 
     injectMessages: function (locale, messages) {
@@ -60,15 +69,16 @@ export default React.createClass({
             }
         });
 
-        // this initializer is specific to the formatjs.io.  This is not something
-        // any consumer of ember-intl will need to do.  It's providing some of the glue
-        // between (Ember + ember-intl) and React
+        // This initializer is specific to the formatjs.io. This is not
+        // something any consumer of ember-intl will need to do. It's providing
+        // some of the glue between (Ember + ember-intl) and React.
         this.app.initializer({
-            name : this.props.exampleId,
+            name : this.props.id,
             after: 'ember-intl-standalone',
 
             initialize: function (container, app) {
-                this.controller = container.lookupFactory('controller:basic').create(this.props.context);
+                this.controller = container.lookupFactory('controller:basic')
+                        .create(this.props.context);
 
                 this.injectMessages(this.props.locales, this.props.messages);
 
@@ -76,7 +86,7 @@ export default React.createClass({
                     template  : Ember.Handlebars.compile(this.props.source),
                     context   : this.controller,
                     container : container
-                }).appendTo(domElement)
+                }).appendTo(domElement);
             }.bind(this)
         });
     },

--- a/shared/components/example.jsx
+++ b/shared/components/example.jsx
@@ -1,0 +1,46 @@
+/* global React */
+
+import LocaleSelect from './locale-select';
+
+export default React.createClass({
+    displayName: 'Example',
+
+    propTypes: {
+        id: React.PropTypes.string.isRequired,
+
+        currentLocale   : React.PropTypes.string.isRequired,
+        availableLocales: React.PropTypes.array.isRequired,
+        onLocaleChange  : React.PropTypes.func.isRequired,
+
+        source: React.PropTypes.element.isRequired,
+        output: React.PropTypes.element.isRequired,
+    },
+
+    render: function () {
+        var props = this.props;
+
+        return (
+            <div id={props.id} className="example">
+                <div className="example-source">
+                    {props.source}
+                </div>
+
+                <div className="example-output">
+                    <h4 className="example-output-heading">Rendered</h4>
+
+                    {props.output}
+
+                    <div className="example-output-controls">
+                        <label>
+                            <span className="example-label">Locale:</span>
+                            <LocaleSelect
+                                availableLocales={props.availableLocales}
+                                value={props.currentLocale}
+                                onChange={props.onLocaleChange} />
+                        </label>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+});

--- a/shared/components/handlebars-example.jsx
+++ b/shared/components/handlebars-example.jsx
@@ -1,100 +1,85 @@
 /* global React */
 
-import ExampleMixin from '../mixins/example';
+import Example from './example';
 import CodeBlock from './code-block';
-import LocaleSelect from './locale-select';
 import HandlebarsOutput from './handlebars-output';
 import {Tabs, Tab} from './tabs';
 
 export default React.createClass({
     displayName: 'HandlebarsExample',
-    mixins     : [ExampleMixin],
 
-    statics: {
-        renderCode: [
-            'var html = template(context, {',
-            '    data: {intl: intlData}',
-            '});'
-        ].join('\n')
-    },
+    propTypes: {
+        id: React.PropTypes.string.isRequired,
 
-    generateRenderCode: function () {
-        var intlData = this.generateIntlData();
+        source: React.PropTypes.shape({
+            template: React.PropTypes.string.isRequired,
+            context : React.PropTypes.string.isRequired,
+            intlData: React.PropTypes.string.isRequired
+        }).isRequired,
 
-        return [
-            'var intlData = ' + JSON.stringify(intlData, null, 4) + ';',
-            '',
-            this.constructor.renderCode
-        ].join('\n');
+        context : React.PropTypes.object.isRequired,
+        message : React.PropTypes.string,
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object,
+
+        currentLocale   : React.PropTypes.string.isRequired,
+        availableLocales: React.PropTypes.array.isRequired,
+        onLocaleChange  : React.PropTypes.func.isRequired,
     },
 
     render: function () {
-        var example          = this.props.example;
-        var currentLocale    = this.state.currentLocale;
-        var availableLocales = this.state.availableLocales;
-        var messages         = this.props.intl.messages[currentLocale];
-        var message          = messages[example.meta.messageId];
+        var props = this.props;
 
         var tabs = [
-            <Tab label="Template" key="template" id={example.id + "-template"}>
+            <Tab label="Template" key="template" id={`${props.id}-template`}>
                 <CodeBlock lang="handlebars">
-                    {example.source.template}
+                    {props.source.template}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Context" key="context" id={example.id + "-context"}>
+            <Tab label="Context" key="context" id={`${props.id}-context`}>
                 <CodeBlock lang="javascript">
-                    {example.source.context}
+                    {props.source.context}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Render" key="render" id={example.id + "-render"}>
+            <Tab label="Render" key="render" id={`${props.id}-render`}>
                 <CodeBlock lang="javascript">
-                    {this.generateRenderCode()}
+{`var intlData = ${props.source.intlData};
+
+var html = template(context, {
+    data: {intl: intlData}
+});`}
                 </CodeBlock>
             </Tab>
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (message) {
+        if (props.message) {
             tabs.splice(1, 0,
-                <Tab label="Message" key="message" id={example.id + "-message"}>
+                <Tab label="Message" key="message" id={`${props.id}-message`}>
                     <CodeBlock highlight={false}>
-                        {message}
+                        {props.message}
                     </CodeBlock>
                 </Tab>
             );
         }
 
         return (
-            <div id={example.id} className="example">
-                <div className="example-source">
-                    <Tabs>
-                        {tabs}
-                    </Tabs>
-                </div>
-
-                <div className="example-output">
-                    <h4 className="example-output-heading">Rendered</h4>
-
+            <Example
+                id={props.id}
+                currentLocale={props.currentLocale}
+                availableLocales={props.availableLocales}
+                onLocaleChange={props.onLocaleChange}
+                source={<Tabs>{tabs}</Tabs>}
+                output={
                     <HandlebarsOutput
-                        locales={currentLocale}
-                        formats={example.meta.formats}
-                        messages={messages}
-                        source={example.source.template}
-                        context={this.evalContext(example.source.context)} />
-
-                    <div className="example-output-controls">
-                        <label>
-                            <span className="example-label">Locale:</span>
-                            <LocaleSelect
-                                availableLocales={availableLocales}
-                                value={currentLocale}
-                                onChange={this.updateLocale} />
-                        </label>
-                    </div>
-                </div>
-            </div>
+                        locales={props.currentLocale}
+                        formats={props.formats}
+                        messages={props.messages}
+                        source={props.source.template}
+                        context={props.context} />
+                } />
         );
     }
 });

--- a/shared/components/handlebars-output.jsx
+++ b/shared/components/handlebars-output.jsx
@@ -4,8 +4,16 @@ export default React.createClass({
     displayName: 'HandlebarsOutput',
 
     propTypes: {
-        source : React.PropTypes.string.isRequired,
-        context: React.PropTypes.object.isRequired
+        source  : React.PropTypes.string.isRequired,
+        context : React.PropTypes.object.isRequired,
+
+        locales : React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.array,
+        ]).isRequired,
+
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object
     },
 
     getInitialState: function () {

--- a/shared/components/react-example.jsx
+++ b/shared/components/react-example.jsx
@@ -1,96 +1,79 @@
 /* global React */
 
-import ExampleMixin from '../mixins/example';
+import Example from './example';
 import CodeBlock from './code-block';
-import LocaleSelect from './locale-select';
 import {Tabs, Tab} from './tabs';
 
 export default React.createClass({
     displayName: 'ReactExample',
-    mixins     : [ExampleMixin],
 
-    statics: {
-        renderCode: [
-            'React.render(',
-            '    <Component {...intlData} />,',
-            '    document.getElementById("example")',
-            ');'
-        ].join('\n')
-    },
+    propTypes: {
+        id       : React.PropTypes.string.isRequired,
+        component: React.PropTypes.func.isRequired,
 
-    generateRenderCode: function () {
-        var intlData = this.generateIntlData();
+        source: React.PropTypes.shape({
+            component: React.PropTypes.string.isRequired,
+            intlData : React.PropTypes.string.isRequired
+        }).isRequired,
 
-        return [
-            'var intlData = ' + JSON.stringify(intlData, null, 4) + ';',
-            '',
-            this.constructor.renderCode
-        ].join('\n');
+        message : React.PropTypes.string,
+        formats : React.PropTypes.object,
+        messages: React.PropTypes.object,
+
+        currentLocale   : React.PropTypes.string.isRequired,
+        availableLocales: React.PropTypes.array.isRequired,
+        onLocaleChange  : React.PropTypes.func.isRequired,
     },
 
     render: function () {
-        var example          = this.props.example;
-        var currentLocale    = this.state.currentLocale;
-        var availableLocales = this.state.availableLocales;
-        var messages         = this.props.intl.messages[currentLocale];
-        var message          = messages[example.meta.messageId];
-
-        var ExampleComponent = example.getComponent();
+        var props            = this.props;
+        var ExampleComponent = props.component;
 
         var tabs = [
-            <Tab label="Component" key="component" id={example.id + "-component"}>
+            <Tab label="Component" key="component" id={`${props.id}-component`}>
                 <CodeBlock lang="javascript">
-                    {example.source.component}
+                    {props.source.component}
                 </CodeBlock>
             </Tab>,
 
-            <Tab label="Render" key="render" id={example.id + "-render"}>
+            <Tab label="Render" key="render" id={`${props.id}-render`}>
                 <CodeBlock lang="javascript">
-                    {this.generateRenderCode()}
+{`var intlData = ${props.source.intlData};
+
+React.render(
+    <Component {...intlData} />,
+    document.getElementById('example')
+);`}
                 </CodeBlock>
             </Tab>
         ];
 
         // Insert a "Message" tab if the example uses an i18n message.
-        if (message) {
+        if (props.message) {
             tabs.splice(1, 0,
-                <Tab label="Message" key="message" id={example.id + "-message"}>
+                <Tab label="Message" key="message" id={`${props.id}-message`}>
                     <CodeBlock highlight={false}>
-                        {message}
+                        {props.message}
                     </CodeBlock>
                 </Tab>
             );
         }
 
         return (
-            <div id={example.id} className="example">
-                <div className="example-source">
-                    <Tabs>
-                        {tabs}
-                    </Tabs>
-                </div>
-
-                <div className="example-output">
-                    <h4 className="example-output-heading">Rendered</h4>
-
+            <Example
+                id={props.id}
+                currentLocale={props.currentLocale}
+                availableLocales={props.availableLocales}
+                onLocaleChange={props.onLocaleChange}
+                source={<Tabs>{tabs}</Tabs>}
+                output={
                     <div className="react-output">
                         <ExampleComponent
-                            locales={currentLocale}
-                            formats={example.meta.formats}
-                            messages={messages} />
+                            locales={props.currentLocale}
+                            formats={props.formats}
+                            messages={props.messages} />
                     </div>
-
-                    <div className="example-output-controls">
-                        <label>
-                            <span className="example-label">Locale:</span>
-                            <LocaleSelect
-                                availableLocales={availableLocales}
-                                value={currentLocale}
-                                onChange={this.updateLocale} />
-                        </label>
-                    </div>
-                </div>
-            </div>
+                } />
         );
     }
 });

--- a/shared/components/splash-example.jsx
+++ b/shared/components/splash-example.jsx
@@ -7,6 +7,22 @@ var CSSTransitionGroup = React.addons.CSSTransitionGroup;
 export default React.createClass({
     displayName: 'SplashExample',
 
+    propTypes: {
+        name     : React.PropTypes.string.isRequired,
+        numPhotos: React.PropTypes.number.isRequired,
+        takenDate: React.PropTypes.number.isRequired,
+
+        locales : React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.array,
+        ]).isRequired,
+
+        messages: React.PropTypes.object.isRequired,
+
+        availableLocales  : React.PropTypes.array.isRequired,
+        availableNumPhotos: React.PropTypes.array.isRequired
+    },
+
     getInitialState: function () {
         var locales = this.props.locales;
 
@@ -25,6 +41,7 @@ export default React.createClass({
     },
 
     render: function () {
+        // This this ref to be lazy.
         var {FormattedMessage} = ReactIntl;
 
         var currentLocale = this.state.currentLocale;

--- a/views/partials/formatjs.hbs
+++ b/views/partials/formatjs.hbs
@@ -23,7 +23,7 @@
 
 {{#if usesEmberIntl}}
 <script src="/vendor/jquery/jquery{{min}}.js"></script>
-<script src="/vendor/ember/ember{{min}}.js"></script>
+<script src="/vendor/ember/ember{{#if min}}{{min}}{{else}}.debug{{/if}}.js"></script>
 <script src="/vendor/ember/ember-template-compiler.js"></script>
 <script src="/vendor/ember-intl/ember-intl{{min}}.js"></script>
 <script src="/vendor/formatjs/ember-intl-locale-data.js"></script>


### PR DESCRIPTION
This replaces the `Example` mixin used by the various `<*Example>` components with a new high-level component: `<ExampleContainer>`, and a new low-level `<Example>` component.

These two new components are used with the `<HandlebarsExample>`, `<ReactExample>`, etc. components to keep thing DRY, and also allow for everything _but_ the `<ExampleContainer>` to be pure components ( i.e., they don't have `state`.)

Now `<ExampleContainer>` contains the state and logic for dealing with an example's `currentLocale`, and once it has the data ready it delegates rendering to the specialized `<*Example>` components for each type of integration.

The new component hierarchy looks like this:

```js
<ExampleContainer {...props} component={HandlebarsExample} />

// The `render()` in <HandlebarsExample> looks like this:

<Example {...props}
     source={<Tabs>{tabs}</Tabs>}
     output={<HandlebarsOutput {...props} />} />
```