### PR TITLE
Move example component selection into container

### DIFF
--- a/lib/examples.js
+++ b/lib/examples.js
@@ -54,9 +54,8 @@ function renderExamples(examples, intl) {
 
     return examples.reduce(function (hash, example) {
         hash[example.name] = component.render('example-container', {
-            component: component.require(example.type + '-example'),
-            example  : example,
-            intl     : intl
+            example: example,
+            intl   : intl
         });
 
         return hash;

--- a/public/js/integration.jsx
+++ b/public/js/integration.jsx
@@ -1,36 +1,24 @@
 /* global React */
 
 import ExampleContainer from './components/example-container';
-import HandlebarsExample from './components/handlebars-example';
-import ReactExample from './components/react-example';
-import DustExample from './components/dust-example';
-import EmberExample from './components/ember-example';
-
-var INTEGRATION_COMPONENTS = {
-    handlebars: HandlebarsExample,
-    react     : ReactExample,
-    dust      : DustExample,
-    ember     : EmberExample
-};
 
 export default function init(state) {
     state.examples.forEach(function (example) {
-        hydrateExample(example.id, example.type, {
+        hydrateExample(example.id, {
             example: example,
             intl   : state.intl
         });
     });
 }
 
-function hydrateExample(id, type, props) {
+function hydrateExample(id, props) {
     var exampleNode = document.getElementById(id);
     if (!exampleNode) { return; }
 
-    var ExampleComponent = INTEGRATION_COMPONENTS[type];
-    var containerNode    = exampleNode.parentNode;
+    var containerNode = exampleNode.parentNode;
 
     containerNode.component = React.render(
-        <ExampleContainer {...props} component={ExampleComponent} />,
+        <ExampleContainer {...props} />,
         containerNode
     );
 }

--- a/shared/components/example-container.jsx
+++ b/shared/components/example-container.jsx
@@ -1,5 +1,17 @@
 /* global React */
 
+import HandlebarsExample from './handlebars-example';
+import ReactExample from './react-example';
+import DustExample from './dust-example';
+import EmberExample from './ember-example';
+
+var INTEGRATION_COMPONENTS = {
+    handlebars: HandlebarsExample,
+    react     : ReactExample,
+    dust      : DustExample,
+    ember     : EmberExample
+};
+
 export default React.createClass({
     displayName: 'ExampleContainer',
 
@@ -7,8 +19,11 @@ export default React.createClass({
         example: React.PropTypes.shape({
             id  : React.PropTypes.string.isRequired,
             name: React.PropTypes.string.isRequired,
-            type: React.PropTypes.string.isRequired,
             meta: React.PropTypes.object.isRequired,
+
+            type: React.PropTypes.oneOf(
+                Object.keys(INTEGRATION_COMPONENTS)
+            ).isRequired,
 
             source: React.PropTypes.shape({
                 template : React.PropTypes.string,
@@ -98,8 +113,8 @@ export default React.createClass({
         var props = this.props;
         var state = this.state;
 
-        var Component = props.component;
-        var example   = props.example;
+        var example          = props.example;
+        var ExampleComponent = INTEGRATION_COMPONENTS[example.type];
 
         var source = Object.assign({}, example.source, {
             intlData: JSON.stringify(this.generateIntlData(), null, 4)
@@ -108,7 +123,7 @@ export default React.createClass({
         var messages = props.intl.messages[state.currentLocale];
 
         return (
-            <Component
+            <ExampleComponent
                 id={example.id}
                 component={example.source.component && example.getComponent()}
                 source={source}


### PR DESCRIPTION
This moves the selection of the example component based on the example's type (e.g., `<HandlebarsExample>`) into the `<ExampleContainer>` component.