### PR TITLE
Update docs on polyfilling Intl in Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "handlebars": "^3.0.0",
     "handlebars-intl": "^1.1.1",
     "intl": "^0.1.4",
+    "intl-locales-supported": "^1.0.0",
     "jquery": "^2.1.3",
     "js-yaml": "^3.2.1",
     "jumanji": "^0.1.1",

--- a/views/pages/dust.hbs
+++ b/views/pages/dust.hbs
@@ -118,11 +118,6 @@ DustIntl.registerWith(dust);
     <h4>1. Require the Module</h4>
 
 {{#code "js"}}
-// Load and use polyfill for ECMA-402.
-if (!global.Intl) {
-    global.Intl = require('intl');
-}
-
 var dust     = require('dustjs-linkedin');
 var DustIntl = require('dust-intl');
 {{/code}}

--- a/views/pages/github.hbs
+++ b/views/pages/github.hbs
@@ -160,6 +160,20 @@
                 Compatibility implementation of the ECMAScript Internationalization API (ECMA-402) for JavaScript. <b>Developed by <a href="https://github.com/andyearnshaw">Andy Earnshaw</a></b>
             </p>
         </div>
+
+        <div class="repo">
+            <h3 class="repo-name">
+                <a href="https://github.com/yahoo/intl-locales-supported">Intl Locales Supported</a>
+            </h3>
+            <div class="repo-badges">
+              {{#with "intl-locales-supported"}}
+                {{> npm-badge}}
+              {{/with}}
+            </div>
+            <p class="repo-description">
+                Utility to help you polyfill the Node.js runtime when the Intl APIs are missing, or if the built-in Intl is missing locale data that you need.
+            </p>
+        </div>
     </div>
 
     <h2 id="website">Website</h2>

--- a/views/pages/guides/runtime-environments.hbs
+++ b/views/pages/guides/runtime-environments.hbs
@@ -52,7 +52,7 @@
             </h3>
 
             <p>
-                The <a href="https://github.com/andyearnshaw/Intl.js">Intl.js</a> library, developed by Andy Earnshaw, provides a polyfill for the {{code "Intl.NumberFormat"}} and {{code "Intl.DateTimeFormat"}} APIs &mdash; both of which are needed by the {{brand}} libraries. The polyfill also includes separate locale data files for each of the 700+ locales it supports.
+                The <a href="https://github.com/andyearnshaw/Intl.js">Intl.js polyfill</a>, developed by Andy Earnshaw, provides a polyfill for the {{code "Intl.NumberFormat"}} and {{code "Intl.DateTimeFormat"}} APIs &mdash; both of which are needed by the {{brand}} libraries. The polyfill also includes separate locale data files for each of the 700+ locales it supports.
             </p>
 
             <p class="note">
@@ -80,22 +80,23 @@
             </h3>
 
             <p>
-                The following code snippet will help you polyfill the Node.js runtime when the {{code "Intl"}} APIs are missing, or if the built-in {{code "Intl"}} is missing locale data that's needed for your app:
+                Node.js <= 0.10 doesn't have the built-in <code>Intl</code> APIs (ECMA-402). Node.js 0.12 does, but the default build/distribution only supports English.
+            </p>
+
+            <p>
+                The following code snippet uses the <a href="https://github.com/andyearnshaw/Intl.js">{{code "intl"}}</a> and <a href="https://github.com/yahoo/intl-locales-supported">{{code "intl-locales-supported"}}</a> npm packages which will help you polyfill the Node.js runtime when the {{code "Intl"}} APIs are missing, or if the built-in {{code "Intl"}} is missing locale data that's needed for your app:
             </p>
 
 {{#code "js"}}
+var areIntlLocalesSupported = require('intl-locales-supported');
+
 var localesMyAppSupports = [
     /* list locales here */
 ];
 
 if (global.Intl) {
     // Determine if the built-in `Intl` has the locale data we need.
-    var hasBuiltInLocaleData = localesMyAppSupports.every(function (locale) {
-        return Intl.NumberFormat.supportedLocalesOf(locale)[0] === locale &&
-                Intl.DateTimeFormat.supportedLocalesOf(locale)[0] === locale;
-    });
-
-    if (!hasBuiltInLocaleData) {
+    if (!areIntlLocalesSupported(localesMyAppSupports)) {
         // `Intl` exists, but it doesn't have the data we need, so load the
         // polyfill and replace the constructors with need with the polyfill's.
         require('intl');
@@ -155,7 +156,7 @@ app.get('/', function (req, res) {
             </h3>
 
             <p>
-                The <a href="https://github.com/andyearnshaw/Intl.js">Intl.js</a> library, developed by Andy Earnshaw, provides a polyfill for the {{code "Intl"}} API. It needs a locale data file for the current page.
+                The <a href="https://github.com/andyearnshaw/Intl.js">Intl.js polyfill</a>, developed by Andy Earnshaw, provides a polyfill for the {{code "Intl"}} API. It needs a locale data file for the current page.
             </p>
 
 {{#code "html"}}

--- a/views/pages/handlebars.hbs
+++ b/views/pages/handlebars.hbs
@@ -122,11 +122,6 @@ HandlebarsIntl.registerWith(Handlebars);
     <h4>1. Require the Module</h4>
 
 {{#code "js"}}
-// Load and use polyfill for ECMA-402.
-if (!global.Intl) {
-    global.Intl = require('intl');
-}
-
 var Handlebars     = require('handlebars');
 var HandlebarsIntl = require('handlebars-intl');
 {{/code}}

--- a/views/pages/react.hbs
+++ b/views/pages/react.hbs
@@ -154,11 +154,6 @@ React.render(
     <h4>Require the Module</h4>
 
 {{#code "js"}}
-// Load and use polyfill for ECMA-402.
-if (!global.Intl) {
-    global.Intl = require('intl');
-}
-
 var React     = require('react');
 var ReactIntl = require('react-intl');
 {{/code}}

--- a/views/partials/integrations/note-intl-browser.hbs
+++ b/views/partials/integrations/note-intl-browser.hbs
@@ -1,3 +1,3 @@
 <p class="note">
-    <strong>Note:</strong> Older browsers and Safari do not provide the global {{code "Intl"}} object (ECMA-402). Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#client">how to patch the browser runtime</a> using a polyfill.
+    <strong>Note:</strong> Older browsers and Safari do not have the built-in {{code "Intl"}} APIs (ECMA-402). Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#client">how to patch the browser runtime</a> using a polyfill.
 </p>

--- a/views/partials/integrations/note-intl-node.hbs
+++ b/views/partials/integrations/note-intl-node.hbs
@@ -1,3 +1,3 @@
 <p class="note">
-    <strong>Note:</strong> Node.js (as of 0.10) doesn't provide the global <code>Intl</code> object (ECMA-402).Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#server">how to patch Node.js</a> using a polyfill.
+    <strong>Note:</strong> Node.js <= 0.10 doesn't have the built-in <code>Intl</code> APIs (ECMA-402). Node.js 0.12 does, but the default build/distribution only supports English. Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#server">how to patch Node.js</a> using a polyfill.
 </p>


### PR DESCRIPTION
This updates the docs on how to polyfill `Intl` in Node.js by using the new `intl-locales-supported` npm package. The docs on each integration page have been improved to not show a polyfilling approach which is incompatible with Node 0.12.

Relates to: yahoo/react-intl#115

/cc @juandopazo @jlecomte 