### PR TITLE
Use path-to-regexp instead of reverend

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,10 +43,10 @@ global.DustIntl.registerWith(global.dust);
 
 // -----------------------------------------------------------------------------
 
-var path     = require('path');
-var express  = require('express');
-var expstate = require('express-state');
-var reverend = require('reverend');
+var path         = require('path');
+var express      = require('express');
+var expstate     = require('express-state');
+var pathToRegexp = require('path-to-regexp');
 
 var hbs        = require('./lib/hbs');
 var middleware = require('./middleware');
@@ -128,7 +128,8 @@ app.getRoute = function (routeName) {
 };
 
 app.getPathTo = function (routeName, context) {
-    return reverend(app.getRoute(routeName).path, context);
+    var toPath = pathToRegexp.compile(app.getRoute(routeName).path);
+    return toPath(context);
 };
 
 // -- Locals -------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "jumanji": "^0.1.1",
     "morgan": "^1.2.3",
     "nodeify": "^1.0.0",
+    "path-to-regexp": "^1.2.0",
     "promise": "^6.1.0",
     "react": "^0.13.1",
     "react-intl": "^1.2.0",
     "react-tools": "^0.13.1",
-    "reverend": "^0.3.0",
     "serve-favicon": "^2.1.1",
     "serve-static": "^1.8.0"
   },


### PR DESCRIPTION
reverend module has been deprecated, and path-to-regexp module has
a similar function called `compile`.

* https://github.com/krakenjs/reverend
* https://github.com/pillarjs/path-to-regexp