### PR TITLE
Redirect /react/ to GitHub, old docs at /react/v1/

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@ router.use(middleware.intl);
 router.use(middleware.polyfills);
 
 route('/guide/').get(routes.redirect('/guides/'));
+route('/react/').get(routes.redirect('https://github.com/yahoo/react-intl'));
 route('/ember/').get(routes.redirect('https://github.com/yahoo/ember-intl'));
 
 routes.home(route('/'));
@@ -111,7 +112,7 @@ routes.guides(route('/guides/:guide?/'));
 routes.integrations(route('/integrations/'));
 routes.github(route('/github/'));
 
-routes.react(route('/react/'));
+routes.react(route('/react/v1/'));
 routes.handlebars(route('/handlebars/'));
 routes.dust(route('/dust/'));
 

--- a/views/pages/home.hbs
+++ b/views/pages/home.hbs
@@ -41,7 +41,7 @@
 
             <div class="integrations-desc">
                 <p>
-                    For most web projects, internationalization happens in the template or view layer, so we've built integrations with common template and component libraries: <a href="{{pathTo 'react'}}">React</a>, <a href="https://github.com/yahoo/ember-intl">Ember</a>, <a href="{{pathTo 'handlebars'}}">Handlebars</a>, and <a href="{{pathTo 'dust'}}">Dust</a>.
+                    For most web projects, internationalization happens in the template or view layer, so we've built integrations with common template and component libraries: <a href="https://github.com/yahoo/react-intl">React</a>, <a href="https://github.com/yahoo/ember-intl">Ember</a>, <a href="{{pathTo 'handlebars'}}">Handlebars</a>, and <a href="{{pathTo 'dust'}}">Dust</a>.
                 </p>
 
                 <p>

--- a/views/partials/integrations-list.hbs
+++ b/views/partials/integrations-list.hbs
@@ -1,6 +1,6 @@
 <ul class="integrations-list">
     <li class="integration">
-        <a class="integration-content" href="{{pathTo 'react'}}">
+        <a class="integration-content" href="https://github.com/yahoo/react-intl">
             <h3 class="integration-name">React</h3>
             <div class="integration-brand">
                 <img class="integration-mark" alt="React logo" src="/img/react.svg">


### PR DESCRIPTION
The docs for React Intl v2 will be on GitHub, so this redirects the `/react/` URL to GitHub, and preserves the older v1 docs at `/react/v1/`.