### PR TITLE
Safari 10 supports the Intl APIs

### DIFF
--- a/views/pages/guides/runtime-environments.hbs
+++ b/views/pages/guides/runtime-environments.hbs
@@ -42,7 +42,7 @@
             </h3>
 
             <p>
-                The {{code "Intl"}} APIs are currently available on Node.js 0.12 and all modern browsers <em>except</em> Safari. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
+                The {{code "Intl"}} APIs are currently available on Node.js 0.12 and all modern browsers. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
             </p>
         </section>
 
@@ -143,7 +143,7 @@ app.get('/', function (req, res) {
         </h2>
 
         <p>
-            The {{code "Intl"}} APIs are currently available on all modern browsers <em>except</em> Safari. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
+            The {{code "Intl"}} APIs are currently available on all modern browsers. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
         </p>
 
         <p>

--- a/views/partials/integrations/note-intl-browser.hbs
+++ b/views/partials/integrations/note-intl-browser.hbs
@@ -1,3 +1,3 @@
 <p class="note">
-    <strong>Note:</strong> Older browsers and Safari do not have the built-in {{code "Intl"}} APIs (ECMA-402). Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#client">how to patch the browser runtime</a> using a polyfill.
+    <strong>Note:</strong> Older browsers do not have the built-in {{code "Intl"}} APIs (ECMA-402). Read more on <a href="{{pathTo 'guides' guide='runtime-environments'}}#client">how to patch the browser runtime</a> using a polyfill.
 </p>


### PR DESCRIPTION
See [Safari 10.0 release notes](https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html).

[Can I use?](http://caniuse.com/#feat=internationalization) shows 0.25% usage so I'm not sure if it's worth changing right now. Up to you!