### PR TITLE
Remove outdated browser support reference

### DIFF
--- a/views/pages/guides/runtime-environments.hbs
+++ b/views/pages/guides/runtime-environments.hbs
@@ -42,7 +42,7 @@
             </h3>
 
             <p>
-                The {{code "Intl"}} APIs are currently available on Node.js 0.12 and all modern browsers, with the exception of Firefox on Android. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
+                The {{code "Intl"}} APIs are currently available on Node.js 0.12 and all modern browsers. See the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility">Mozilla Developer Network documentation</a> for an up-to-date list of capable browsers.
             </p>
         </section>
 


### PR DESCRIPTION
As you can see here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Browser_Compatibility Firefox on Android is now supported

<img width="1054" alt="firefox" src="https://user-images.githubusercontent.com/767959/39238434-7fd9d9b2-487e-11e8-8a2c-92a0e092b6e1.png">
